### PR TITLE
Prevent creation of default 'Hello World' and 'Sample page' posts.

### DIFF
--- a/app/install.php
+++ b/app/install.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Prevents generation of 'Hello World' and 'Sample Page'.
+ * @link http://wordpress.stackexchange.com/a/71867/8872
+ */
+function wp_install_defaults() {
+    return null;
+}


### PR DESCRIPTION
I use this as a standard part of my install when using WordPress as an app framework. As often your 'app' doesn't use one or either of the standard post types. This also prevents the creation of default taxonomies and terms.

Uses the pluggable wp_install_defaults() function.
