### PR TITLE
Add SCRIPT_DEBUG constant to allow loading of optimised CSS/JS.

### DIFF
--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -10,3 +10,4 @@ define('WP_SITEURL', getenv('WP_SITEURL'));
 
 define('SAVEQUERIES', true);
 define('WP_DEBUG', true);
+define('SCRIPT_DEBUG', true);

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -10,3 +10,4 @@ define('WP_SITEURL', getenv('WP_SITEURL'));
 
 ini_set('display_errors', 0);
 define('WP_DEBUG_DISPLAY', false);
+define('SCRIPT_DEBUG', false);

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -10,3 +10,4 @@ define('WP_SITEURL', getenv('WP_SITEURL'));
 
 ini_set('display_errors', 0);
 define('WP_DEBUG_DISPLAY', false);
+define('SCRIPT_DEBUG', false);


### PR DESCRIPTION
Adds the constant if it has been defined in the env file, otherwise defaults to true on development and false on staging and prod.

Theme developers using a build script for their CSS/JS can use this to enqueue the un-minified version of scripts for debugging during development and switch to the concatenated/minified version on staging and production. For example:

``` php
function my_enqueue_function() {

    if ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) {
        wp_enqueue_style( 'example-lib-1' );
        wp_enqueue_style( 'style-dev' );

        wp_enqueue_script( 'jquery' );
        wp_enqueue_script( 'app' );
    } else {
        wp_enqueue_style( 'build-css' );
        wp_enqueue_style( 'build-js' );
    }
}
```

More info on [SCRIPT_DEBUG](http://codex.wordpress.org/Editing_wp-config.php#Debug)
