### PR TITLE
Add post-root-package-install script for generating Salts/Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ If you aren't interested in using a part, then you don't need its requirements e
 
 See [Documentation](#documentation) for more details on the steps below.
 
+### Using `create-project`
+
+Composer's `create-project` command will automatically install the Bedrock project to a directory and run `composer install`.
+
+The post-install script will automatically copy `.env.example` to `.env` and you'll be prompted about generating salt keys and appending them to your `.env` file.
+
+Note: To generate salts without a prompt, run `create-project` with `-n` (non-interactive). You can also change the `generate-salts` setting in `composer.json` under `config` in your own fork. The default is `true`.
+
+1. Run `composer create-project roots/bedrock <path>` (`path` being the folder to install to)
+2. Edit `.env` and update environment variables:
+  * `DB_NAME` - Database name
+  * `DB_USER` - Database user
+  * `DB_PASSWORD` - Database password
+  * `DB_HOST` - Database host (defaults to `localhost`)
+  * `WP_ENV` - Set to environment (`development`, `staging`, `production`, etc)
+  * `WP_HOME` - Full URL to WordPress home (http://example.com)
+  * `WP_SITEURL` - Full URL to WordPress including subdirectory (http://example.com/wp)
+3. Add theme(s)
+4. Access WP Admin at `http://example.com/wp/wp-admin`
+
+### Manually
+
 1. Clone/Fork repo
 2. Run `composer install`
 3. Copy `.env.example` to `.env` and update environment variables:

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,20 @@
   "keywords": [
     "wordpress", "stack", "capistrano", "composer", "vagrant", "wp"
   ],
+  "support": {
+    "issues": "https://github.com/roots/bedrock/issues",
+    "forum": "http://discourse.roots.io/category/bedrock"
+  },
+  "config": {
+    "preferred-install": "dist",
+    "generate-salts": true
+  },
+  "autoload": {
+    "psr-0": {"Bedrock\\Installer": "scripts"}
+  },
+  "scripts": {
+    "post-root-package-install": ["Bedrock\\Installer::addSalts"]
+  },
   "repositories": [
     {
       "type": "composer",

--- a/config/application.php
+++ b/config/application.php
@@ -35,16 +35,15 @@ $table_prefix = 'wp_';
 
 /**
  * Authentication Unique Keys and Salts
- * https://api.wordpress.org/secret-key/1.1/salt
  */
-define('AUTH_KEY',         'put your unique phrase here');
-define('SECURE_AUTH_KEY',  'put your unique phrase here');
-define('LOGGED_IN_KEY',    'put your unique phrase here');
-define('NONCE_KEY',        'put your unique phrase here');
-define('AUTH_SALT',        'put your unique phrase here');
-define('SECURE_AUTH_SALT', 'put your unique phrase here');
-define('LOGGED_IN_SALT',   'put your unique phrase here');
-define('NONCE_SALT',       'put your unique phrase here');
+define('AUTH_KEY',         getenv('AUTH_KEY'));
+define('SECURE_AUTH_KEY',  getenv('SECURE_AUTH_KEY'));
+define('LOGGED_IN_KEY',    getenv('LOGGED_IN_KEY'));
+define('NONCE_KEY',        getenv('NONCE_KEY'));
+define('AUTH_SALT',        getenv('AUTH_SALT'));
+define('SECURE_AUTH_SALT', getenv('SECURE_AUTH_SALT'));
+define('LOGGED_IN_SALT',   getenv('LOGGED_IN_SALT'));
+define('NONCE_SALT',       getenv('NONCE_SALT'));
 
 /**
  * Custom Settings

--- a/scripts/Bedrock/Installer.php
+++ b/scripts/Bedrock/Installer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Bedrock;
+
+use Composer\Script\Event;
+
+class Installer {
+  public static $KEYS = array(
+    'AUTH_KEY',
+    'SECURE_AUTH_KEY',
+    'LOGGED_IN_KEY',
+    'NONCE_KEY',
+    'AUTH_SALT',
+    'SECURE_AUTH_SALT',
+    'LOGGED_IN_SALT',
+    'NONCE_SALT'
+  );
+
+  public static function addSalts(Event $event) {
+    $root = dirname(dirname(__DIR__));
+    $composer = $event->getComposer();
+    $io = $event->getIO();
+
+    if (!$io->isInteractive()) {
+      $generate_salts = $composer->getConfig()->get('generate-salts');
+    } else {
+      $generate_salts = $io->askConfirmation('<info>Generate salts and append to .env file?</info> [<comment>Y,n</comment>]? ', true);
+    }
+
+    if (!$generate_salts) {
+      return 1;
+    }
+
+    $salts = array_map(function ($key) {
+      return "$key=" . self::generate_salt();
+    }, self::$KEYS);
+
+    $env_file = "{$root}/.env";
+
+    if (copy("{$root}/.env.example", $env_file)) {
+      file_put_contents($env_file, implode($salts, "\n"), FILE_APPEND | LOCK_EX);
+    } else {
+      $io->write("<error>An error occured while copying your .env file</error>");
+      return 1;
+    }
+  }
+
+  /**
+   * Slightly modified/simpler version of wp_generate_password
+   * https://github.com/WordPress/WordPress/blob/cd8cedc40d768e9e1d5a5f5a08f1bd677c804cb9/wp-includes/pluggable.php#L1575
+   */
+  public static function generate_salt($length = 64) {
+    $chars  = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    $chars .= '!@#$%^&*()';
+    $chars .= '-_ []{}<>~`+=,.;:/?|';
+
+    $salt = '';
+    for ($i = 0; $i < $length; $i++) {
+      $salt .= substr($chars, rand(0, strlen($chars) - 1), 1);
+    }
+
+    return $salt;
+  }
+}


### PR DESCRIPTION
Adds a script that's run on the `post-root-package-install` event. The script copies `.env.example` to `.env` and generates all the necessary salts/keys for WP and appends them to `.env`.

In interactive mode, there's a prompt for the generation. In non-interactive mode (`-n` flag), the `config.generate-salts` option is read from `composer.json` to determine if it's run or not.
