### PR TITLE
Added exception for app/plugins/.gitkeep in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ sql-dump-*.sql
 app/uploads
 app/upgrade
 app/plugins/*
+!app/plugins/.gitkeep
 app/mu-plugins/*
 !app/mu-plugins/register-theme-directory.php
 


### PR DESCRIPTION
Was confused for a minute when my plugins-folder with the .gitkeep didn't show up in my repo. Turns out the plugins has a .gitkeep which isn't used because of .gitignore setting: app/plugins/*. This fixes that.
