### PR TITLE
Added theme directory to installer-paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
   "extra": {
     "installer-paths": {
       "app/plugins/{$name}/": ["type:wordpress-plugin"],
-      "app/mu-plugins/{$name}/": ["type:wordpress-muplugin"]
+      "app/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
+      "app/themes/{$name}/": ["type:wordpress-theme"]
     },
     "webroot-dir": "wp",
     "webroot-package": "wordpress"


### PR DESCRIPTION
Added theme directory to installer-paths so if you, for example, add roots theme to the composer.json it will be installed in the right directory.
