### PR TITLE
Enclose salt-related values in .env with single quotes

### DIFF
--- a/scripts/Bedrock/Installer.php
+++ b/scripts/Bedrock/Installer.php
@@ -32,7 +32,7 @@ class Installer {
     }
 
     $salts = array_map(function ($key) {
-	  return sprintf( "%s='%s'", $key, self::generate_salt() );
+      return sprintf("%s='%s'", $key, self::generate_salt());
     }, self::$KEYS);
 
     $env_file = "{$root}/.env";


### PR DESCRIPTION
This is useful in case we need to source the .env file from a shell script
