### PR TITLE
Interactive .env file creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "psr-0": {"Bedrock\\Installer": "scripts"}
   },
   "scripts": {
-    "post-root-package-install": ["Bedrock\\Installer::addSalts"]
+    "post-root-package-install": ["Bedrock\\Installer::createEnv"]
   },
   "repositories": [
     {

--- a/scripts/Bedrock/Installer.php
+++ b/scripts/Bedrock/Installer.php
@@ -5,7 +5,9 @@ namespace Bedrock;
 use Composer\Script\Event;
 
 class Installer {
-  public static $KEYS = array(
+  public static $env_vars = array();
+
+  public static $salt_keys = array(
     'AUTH_KEY',
     'SECURE_AUTH_KEY',
     'LOGGED_IN_KEY',
@@ -16,32 +18,93 @@ class Installer {
     'NONCE_SALT'
   );
 
-  public static function addSalts(Event $event) {
+  public static function createEnv(Event $event) {
     $root = dirname(dirname(__DIR__));
     $composer = $event->getComposer();
     $io = $event->getIO();
 
+    $domain = basename($root);
+    $env = array(
+      'WP_ENV' => array(
+        'default'  => 'development',
+        'question' => 'Environment',
+      ),
+      'DOMAIN_CURRENT_SITE' => array(
+        'default'  => $domain,
+        'question' => '(Main site) Domain Name',
+      ),
+      'DB_NAME' => array(
+        'default'  => $domain,
+        'question' => 'Database Name',
+      ),
+      'DB_USER' => array(
+        'default'  => 'wp',
+        'question' => 'Database User',
+      ),
+      'DB_PASSWORD' => array(
+        'default'  => 'wp',
+        'question' => 'Database Password',
+      ),
+      'DB_HOST' => array(
+        'default'  => 'localhost',
+        'question' => 'Database Host',
+      ),
+    );
+
     if (!$io->isInteractive()) {
+      array_walk(
+        $env,
+        function(&$props, $key) {
+          $props = $props['default'];
+          if ('DB_NAME' === $key || 'DB_USER' === $key) {
+            $props = self::stripNonAlphaNumerics($props);
+          }
+        }
+      );
+      self::$env_vars = $env;
+
       $generate_salts = $composer->getConfig()->get('generate-salts');
-    } else {
-      $generate_salts = $io->askConfirmation('<info>Generate salts and append to .env file?</info> [<comment>Y,n</comment>]? ', true);
+    }
+    else {
+      foreach ($env as $key => $props) {
+        $value = $io->ask(sprintf('<info>%s</info> [<comment>%s</comment>] ', $props['question'], $props['default']), $props['default']);
+        if ('DB_NAME' === $key || 'DB_USER' === $key) {
+          $value = self::stripNonAlphaNumerics($value);
+          if (empty($value)) {
+      $value = $props['default'];
+          }
+        }
+
+        self::$env_vars[$key] = $value;
+      }
+
+      $generate_salts = $io->askConfirmation('<info>Generate salts?</info> [<comment>Y,n</comment>]? ', true);
     }
 
-    if (!$generate_salts) {
-      return 1;
+    self::$env_vars['WP_HOME']    = sprintf('http://%s', self::$env_vars['DOMAIN_CURRENT_SITE']);
+    self::$env_vars['WP_SITEURL'] = sprintf('%s/wp', self::$env_vars['WP_HOME']);
+
+    if ($generate_salts) {
+      foreach (self::$salt_keys as $key) {
+        self::$env_vars[$key] = self::generate_salt();
+      }
     }
 
-    $salts = array_map(function ($key) {
-      return sprintf("%s='%s'", $key, self::generate_salt());
-    }, self::$KEYS);
+    $env_file = $root . '/.env';
+    $env_vars = array();
+    foreach (self::$env_vars as $key => $value) {
+      $env_vars[] = sprintf("%s='%s'", $key, $value);
+    }
+    $env_vars = implode("\n", $env_vars) . "\n";
 
-    $env_file = "{$root}/.env";
-
-    if (copy("{$root}/.env.example", $env_file)) {
-      file_put_contents($env_file, implode($salts, "\n"), FILE_APPEND | LOCK_EX);
-    } else {
-      $io->write("<error>An error occured while copying your .env file</error>");
-      return 1;
+    try {
+      file_put_contents($env_file, $env_vars, LOCK_EX);
+      $io->write("<info>.env file successfully created.</info>");
+    } catch (\Exception $e) {
+      $io->write('<error>An error occured while creating your .env file. Error message:</error>');
+      $io->write(sprintf('<error>%s</error>%s', $e->getMessage(), "\n"));
+      $io->write('<info>Below is the environment variables generated:</info>');
+      $io->write($env_vars);
     }
   }
 
@@ -60,5 +123,9 @@ class Installer {
     }
 
     return $salt;
+  }
+
+  public static function stripNonAlphaNumerics($string) {
+    return preg_replace('/[^a-zA-Z0-9_]+/', '_', $string);
   }
 }


### PR DESCRIPTION
Some info:
- `DOMAIN_CURRENT_SITE` was added for multisite support (AFAIK, it won't hurt non-multisite installs)
- Default values of `DB_USER`, `DB_PASSWORD` & `DB_HOST` were set to their defaults in [VVV](https://github.com/10up/varying-vagrant-vagrants)
