### PR TITLE
Cleaner path to Custom Content and WordPress directory

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -65,5 +65,5 @@ define('DISALLOW_FILE_EDIT', true);
  * Bootstrap WordPress
  */
 if (!defined('ABSPATH')) {
-define('ABSPATH', APP_ROOT . '/wp/');
+  define('ABSPATH', APP_ROOT . '/wp/');
 }


### PR DESCRIPTION
A few minor changes in `application.php`:
- Changed constant to `dirname(__DIR__)` in $root_dir
- Less cluttered way to define path to the Custom Content Directory
- Updated `ABSPATH` to WordPress Directory
