### PR TITLE
Update to Capistrano 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 
+* Update to Capistrano 3.1.0: `deploy:restart` is no longer run by default
 * Better webroot structure: introduces the `/web` directory as the document/web root for web server vhosts
 
 ### 1.0.0: 2013-12-18

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'capistrano', '~> 3.0.1'
+gem 'capistrano', '~> 3.1.0'
 gem 'capistrano-composer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    capistrano (3.0.1)
+    capistrano (3.1.0)
       i18n
       rake (>= 10.0.0)
-      sshkit (>= 0.0.23)
+      sshkit (~> 1.3)
     capistrano-composer (0.0.3)
       capistrano (>= 3.0.0.pre)
     i18n (0.6.9)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (2.7.0)
-    rake (10.1.0)
-    sshkit (1.2.0)
+    net-ssh (2.8.0)
+    rake (10.1.1)
+    sshkit (1.3.0)
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    term-ansicolor (1.2.2)
-      tins (~> 0.8)
-    tins (0.13.1)
+    term-ansicolor (1.3.0)
+      tins (~> 1.0)
+    tins (1.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  capistrano (~> 3.0.1)
+  capistrano (~> 3.1.0)
   capistrano-composer

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Using Capistrano for deploys?
 
 Required Gems:
 
-* capistrano (> 3.0.1)
+* capistrano (> 3.1.0)
 * capistrano-composer
 
 These can be installed manually with `gem install <gem name>` but it's highly suggested you use [Bundler](http://bundler.io/) to manage them. Bundler is basically the Ruby equivalent to PHP's Composer. Just as Composer manages your PHP packages/dependencies, Bundler manages your Ruby gems/dependencies. Bundler itself is a Gem and can be installed via `gem install bundler` (sudo may be required).

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -20,14 +20,15 @@ set :linked_files, %w{.env}
 set :linked_dirs, %w{app/uploads}
 
 namespace :deploy do
-
   desc 'Restart application'
   task :restart do
     on roles(:app), in: :sequence, wait: 5 do
-      # This task is required by Capistrano but can be a no-op
       # Your restart mechanism here, for example:
       # execute :service, :nginx, :reload
     end
   end
-
 end
+
+# The above restart task is not run by default
+# Uncomment the following line to run it on deploys if needed
+# after 'deploy:publishing', 'deploy:restart'


### PR DESCRIPTION
https://github.com/capistrano/capistrano/blob/master/CHANGELOG.md

`deploy:restart` no longer being run by default is the only breaking change.
