### PR TITLE
Add wordpress namespace for wordpress package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     {
       "type": "package",
       "package": {
-        "name": "wordpress",
+        "name": "wordpress/wordpress",
         "version": "3.8.1",
         "type": "webroot",
         "dist": {
@@ -56,7 +56,7 @@
   ],
   "require": {
     "php": ">=5.3.2",
-    "wordpress": "3.8.1",
+    "wordpress/wordpress": "3.8.1",
     "fancyguy/webroot-installer": "1.1.0",
     "composer/installers": "v1.0.12",
     "vlucas/phpdotenv": "~1.0.6"
@@ -68,6 +68,6 @@
       "web/app/themes/{$name}/": ["type:wordpress-theme"]
     },
     "webroot-dir": "web/wp",
-    "webroot-package": "wordpress"
+    "webroot-package": "wordpress/wordpress"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "3586f00e096276b9f962a6e14853ab69",
+    "hash": "22bca53e249f9c980af0d7928c3077f7",
     "packages": [
         {
             "name": "composer/installers",
@@ -178,7 +178,7 @@
             "time": "2014-01-31 16:18:39"
         },
         {
-            "name": "wordpress",
+            "name": "wordpress/wordpress",
             "version": "3.8.1",
             "dist": {
                 "type": "zip",


### PR DESCRIPTION
All packages in Composer should have a vendor. This finally adds one and we're going with `wordpress` itself since we're using the official WordPress repository itself and not a fork that we/anyone else maintains.
