### PR TITLE
Check if .env exists before running dotenv on it.

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -5,7 +5,10 @@ $webroot_dir = $root_dir . '/web';
 /**
  * Use Dotenv to set required environment variables and load .env file in root
  */
-Dotenv::load($root_dir);
+if (file_exists($root_dir . '/.env')) {
+  Dotenv::load($root_dir);
+}
+
 Dotenv::required(array('DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL'));
 
 /**


### PR DESCRIPTION
On machines where the environment variables have been defined manually, rather than in a .env file, running Dotenv::load or required seems to break the variables.  This runs a check for a .env file before trying to load the variables from there.
