### PR TITLE
Update composer.lock with wordpress 3.9

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "a83e040cb58281b0c8d5317d2ecf7603",
+    "hash": "bc78dfb47ea03142c13601f0d8ca2c8b",
     "packages": [
         {
             "name": "composer/installers",
@@ -46,7 +46,7 @@
                 {
                     "name": "Kyle Robinson Young",
                     "email": "kyle@dontkry.com",
-                    "homepage": "https://github.com/shama",
+                    "homepage": "http://dontkry.com",
                     "role": "Developer"
                 }
             ],
@@ -122,7 +122,7 @@
             ],
             "authors": [
                 {
-                    "name": "Steve Buzonas",
+                    "name": "Steve Buzonas (slbmeh)",
                     "email": "steve@fancyguy.com",
                     "homepage": "http://www.stevebuzonas.com"
                 }
@@ -179,10 +179,10 @@
         },
         {
             "name": "wordpress/wordpress",
-            "version": "3.8.3",
+            "version": "3.9",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/WordPress/WordPress/archive/3.8.3.zip",
+                "url": "https://wordpress.org/wordpress-3.9.zip",
                 "reference": null,
                 "shasum": null
             },


### PR DESCRIPTION
At the moment 'composer create-project' breaks (with an error) on bedrock because the composer.lock isn't updated accordingly to composer.json. I think this solves it. All I did was to fork it, clone it, run composer update wordpress/wordpress (which also did some updates for composer/installer). Might be confusing to new folks with the error, so I thought I'd give it a try and that this would be a reasonable pull request! :)

Untested since I don't have a project on composer to simulate it all the way!!!

Happy easter from Sweden!
