### PR TITLE
Disallow indexing when environment isn't production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ web/app/mu-plugins/*
 web/app/upgrade
 web/app/uploads/*
 !web/app/uploads/.gitkeep
+!web/app/mu-plugins/disallow-indexing.php
 !web/app/mu-plugins/register-theme-directory.php
 
 # Vendor (e.g. Composer)

--- a/web/app/mu-plugins/disallow-indexing.php
+++ b/web/app/mu-plugins/disallow-indexing.php
@@ -1,0 +1,14 @@
+<?php
+/*
+Plugin Name:  Disallow Indexing
+Plugin URI:   http://roots.io/wordpress-stack/
+Description:  Disallow indexing of your site on non-production environments.
+Version:      1.0.0
+Author:       Roots
+Author URI:   http://roots.io/
+License:      MIT License
+*/
+
+if (WP_ENV !== 'production' && !is_admin()) {
+  add_action('pre_option_blog_public', '__return_zero');
+}


### PR DESCRIPTION
Add a mu-plugin that will disallow robots/indexing if the environment isn't production. 

The plugin will just set the [`blog_public` option](http://codex.wordpress.org/Option_Reference#Privacy) to false, which takes care of adding the robots meta (noindex,nofollow) to `<head>`, along with adding the proper `Disallow` to `robots.txt`
