### PR TITLE
Double slash on WP_CONTENT_URL

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -26,8 +26,8 @@ if (file_exists($env_config)) {
 /**
  * Custom Content Directory
  */
-define('CONTENT_DIR', '/app');
-define('WP_CONTENT_DIR', $webroot_dir . CONTENT_DIR);
+define('CONTENT_DIR', 'app');
+define('WP_CONTENT_DIR', $webroot_dir . '/' . CONTENT_DIR);
 define('WP_CONTENT_URL', WP_HOME . CONTENT_DIR);
 
 /**


### PR DESCRIPTION
With the actual config, content urls have bad format like: http://example.com//app/image.jpeg

A second **/** is added before app.

Here is a quick fix on application.php.

Thanks.
