### PR TITLE
Add optional DB_PREFIX configuration option

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -35,7 +35,7 @@ define('WP_CONTENT_URL', WP_HOME . CONTENT_DIR);
  */
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
-$table_prefix = 'wp_';
+$table_prefix = getenv('DB_PREFIX') ? getenv('DB_PREFIX') : 'wp_';
 
 /**
  * WordPress Localized Language


### PR DESCRIPTION
This is helpful to run bedrock in different server environments where you might need a customized prefix.
