### PR TITLE
changed commented public-key path to standard relative path

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -15,7 +15,7 @@ server 'example.com', user: 'deploy', roles: %w{web app db}
 # you can see them in [net/ssh documentation](http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start)
 # set it globally
 #  set :ssh_options, {
-#    keys: %w(/home/rlisowski/.ssh/id_rsa),
+#    keys: %w(~/.ssh/id_rsa),
 #    forward_agent: false,
 #    auth_methods: %w(password)
 #  }

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -15,7 +15,7 @@ server 'example.com', user: 'deploy', roles: %w{web app db}
 # you can see them in [net/ssh documentation](http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start)
 # set it globally
 #  set :ssh_options, {
-#    keys: %w(/home/rlisowski/.ssh/id_rsa),
+#    keys: %w(~/.ssh/id_rsa),
 #    forward_agent: false,
 #    auth_methods: %w(password)
 #  }


### PR DESCRIPTION
the give path to the public key is pretty hard-coded and only fits to rlisowski environment - who ever that is :octopus: 

I think setting it to the default path is more useful - please review
