### PR TITLE
Add Capistrano task to update WordPress theme path

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -32,3 +32,29 @@ end
 # The above restart task is not run by default
 # Uncomment the following line to run it on deploys if needed
 # after 'deploy:publishing', 'deploy:restart'
+
+namespace :deploy do
+  desc 'Update WordPress template root paths to point to the new release'
+  task :update_option_paths do
+    on roles(:app) do
+      within fetch(:release_path) do
+        if test :wp, :core, 'is-installed'
+          [:stylesheet_root, :template_root].each do |option|
+            # Only change the value if it's an absolute path
+            # i.e. The relative path "/themes" must remain unchanged
+            # Also, the option might not be set, in which case we leave it like that
+            value = capture :wp, :option, :get, option, raise_on_non_zero_exit: false
+            if value != '' && value != '/themes'
+              execute :wp, :option, :set, option, fetch(:release_path).join('web/wp/wp-content/themes')
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+# The above update_option_paths task is not run by default
+# Note that you need to have WP-CLI installed on your server
+# Uncomment the following line to run it on deploys if needed
+# after 'deploy:publishing', 'deploy:update_option_paths'


### PR DESCRIPTION
Fixes https://github.com/roots/bedrock/issues/98. Tested with Capistrano 3.2.1 and WordPress 4.0.
