### PR TITLE
Reordering installer paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,8 +63,8 @@
   },
   "extra": {
     "installer-paths": {
-      "web/app/plugins/{$name}/": ["type:wordpress-plugin"],
       "web/app/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
+      "web/app/plugins/{$name}/": ["type:wordpress-plugin"],
       "web/app/themes/{$name}/": ["type:wordpress-theme"]
     },
     "webroot-dir": "web/wp",


### PR DESCRIPTION
Moving muplugins above plugins in order to correctly overload plugins as muplugins.
