### PR TITLE
Add Dotenv To Deployment Process

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -7,6 +7,12 @@ require 'capistrano/deploy'
 # Load tasks from gems
 require 'capistrano/composer'
 
+# Dotenv Support
+require 'dotenv'
+
+# Load Dotenv Variables
+Dotenv.load
+
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 # Customize this path to change the location of your custom tasks.
 Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'dotenv-rails'
 gem 'capistrano', '~> 3.2.0'
 gem 'capistrano-composer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,9 @@ GEM
     capistrano-composer (0.0.4)
       capistrano (>= 3.0.0.pre)
     colorize (0.7.3)
+    dotenv (1.0.2)
+    dotenv-rails (1.0.2)
+      dotenv (= 1.0.2)
     i18n (0.6.9)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -24,3 +27,4 @@ PLATFORMS
 DEPENDENCIES
   capistrano (~> 3.2.0)
   capistrano-composer
+  dotenv-rails


### PR DESCRIPTION
# Proposal

Add functionality to include dotenv variables in Capistrano during deployment. This could be used to prevent SSH credentials from being stored in the version control system.

**Changes made to Bedrock**
- Add dotenv to Capfile
- Load dotenv variables in Capistrano
- Update Gemfile
- Update Gemfile.lock
