### PR TITLE
Text files should end on a newline character

### DIFF
--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -11,3 +11,4 @@ define('WP_SITEURL', getenv('WP_SITEURL'));
 define('SAVEQUERIES', true);
 define('WP_DEBUG', true);
 define('SCRIPT_DEBUG', true);
+

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -11,3 +11,4 @@ define('WP_SITEURL', getenv('WP_SITEURL'));
 ini_set('display_errors', 0);
 define('WP_DEBUG_DISPLAY', false);
 define('SCRIPT_DEBUG', false);
+

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -11,3 +11,4 @@ define('WP_SITEURL', getenv('WP_SITEURL'));
 ini_set('display_errors', 0);
 define('WP_DEBUG_DISPLAY', false);
 define('SCRIPT_DEBUG', false);
+


### PR DESCRIPTION
According to [PSR-2](http://www.php-fig.org/psr/psr-2/):

> All PHP files MUST end with a single blank line.
