### PR TITLE
Boolean should be compared strictly

### DIFF
--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -78,7 +78,7 @@ class Autoloader {
   private function checkCache() {
     $cache = get_site_option('bedrock_autoloader');
 
-    if ($cache == false) {
+    if ($cache === false) {
       return $this->updateCache();
     }
 


### PR DESCRIPTION
> With booleans, only strict comparison (with === operator) should be used to lower bug risks and to improve performances.

We only want the `updateCache` method to run if the site option is explicitly set to `false`.
