### PR TITLE
Set PHP version requirement back to >= 5.3.2. Fixes #120

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.3.2",
     "johnpbloch/wordpress": "4.0.1",
     "composer/installers": "v1.0.12",
     "vlucas/phpdotenv": "1.0.9"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,9 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
-        "This file is @generated automatically"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "f294c1d4ba13182818bd55e3395f87c9",
+    "hash": "161ddfb8f1abb750d0ea3d83fb7dc935",
     "packages": [
         {
             "name": "composer/installers",
@@ -224,13 +223,20 @@
             "time": "2014-10-16 14:50:21"
         }
     ],
-    "packages-dev": [],
-    "aliases": [],
+    "packages-dev": [
+
+    ],
+    "aliases": [
+
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
-    "prefer-stable": false,
+    "stability-flags": [
+
+    ],
     "platform": {
-        "php": ">=5.4"
+        "php": ">=5.3.2"
     },
-    "platform-dev": []
+    "platform-dev": [
+
+    ]
 }


### PR DESCRIPTION
This seems to solve the issue and still allow `composer update` / `composer install` to run without issue.
