### PR TITLE
Remove duplicate "application.php" in illustrative folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,10 @@ See http://capistranorb.com/documentation/getting-started/authentication-and-aut
 │   │   ├── staging.rb
 │   │   └── production.rb
 │   ├── deploy.rb
-│   ├── environments
-│   │   ├── development.php
-│   │   ├── staging.php
-│   │   └── production.php
-│   └── application.php
+│   └── environments
+│       ├── development.php
+│       ├── staging.php
+│       └── production.php
 ├── Gemfile
 ├── vendor
 └── web


### PR DESCRIPTION
Just a tiny fix in order to avoid confusion in readers' minds.
