### PR TITLE
Truly disable all updates via WP admin UI

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -52,9 +52,8 @@ define('NONCE_SALT',       getenv('NONCE_SALT'));
 /**
  * Custom Settings
  */
-define('AUTOMATIC_UPDATER_DISABLED', true);
+define('DISALLOW_FILE_MODS', true);
 define('DISABLE_WP_CRON', true);
-define('DISALLOW_FILE_EDIT', true);
 
 /**
  * Bootstrap WordPress


### PR DESCRIPTION
Based on [this article](https://make.wordpress.org/core/2013/10/25/the-definitive-guide-to-disabling-auto-updates-in-wordpress-3-7/) about completely disabling automatic and/or UI-driven updates in WP (which is what we want in Bedrock AFAIK) and on my own experiments:

`DISALLOW_FILE_MODS` implicitly includes `AUTOMATIC_UPDATER_DISABLED` and `DISALLOW_FILE_EDIT`, plus:
- It hides the update notifications in the admin bar.
- It hides the "Updates" sub-menu in the "Dashboard" admin menu.
- It hides the "Update Available" messages in "Appearance -> Themes" and "Plugins -> Installed Plugins".

I verified in the WP source that `DISALLOW_FILE_MODS` actually includes `AUTOMATIC_UPDATER_DISABLED` and `DISALLOW_FILE_EDIT`, and it is confirmed respectively [here](https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/class-wp-upgrader.php#L2374) and [here](https://github.com/WordPress/WordPress/blob/master/wp-includes/capabilities.php#L1258).
