### PR TITLE
Disable UI-driven updates in staging and production

### DIFF
--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -11,3 +11,4 @@ define('WP_SITEURL', getenv('WP_SITEURL'));
 ini_set('display_errors', 0);
 define('WP_DEBUG_DISPLAY', false);
 define('SCRIPT_DEBUG', false);
+define('DISALLOW_FILE_MODS', true); // this disables all file modifications including updates and update notifications

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -11,3 +11,4 @@ define('WP_SITEURL', getenv('WP_SITEURL'));
 ini_set('display_errors', 0);
 define('WP_DEBUG_DISPLAY', false);
 define('SCRIPT_DEBUG', false);
+define('DISALLOW_FILE_MODS', true); // this disables all file modifications including updates and update notifications


### PR DESCRIPTION
This PR follows the initial merge (5f84a32) and revert (627b63d) of commit 0751c5a.

See this PR for the initial discussion: #125

I took the liberty of adding a single new line at the end of `staging.php` and `production.php` (it's actually the default behavior in my Sublime Text config), as it seemed to already be the standard in most of the other project files.
