### PR TITLE
Fixes gitignore to ignore directories properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,19 +12,19 @@ sql-dump-*.sql
 !.env.example
 
 # Application
-web/app/plugins/*
+web/app/plugins
 !web/app/plugins/.gitkeep
-web/app/mu-plugins/*
+web/app/mu-plugins
 !web/app/mu-plugins/.gitkeep
 web/app/upgrade
-web/app/uploads/*
+web/app/uploads
 !web/app/uploads/.gitkeep
 !web/app/mu-plugins/disallow-indexing.php
 !web/app/mu-plugins/register-theme-directory.php
 !web/app/mu-plugins/bedrock-autoloader.php
 
 # Vendor (e.g. Composer)
-vendor/*
+vendor
 !vendor/.gitkeep
 
 # Node Package Manager


### PR DESCRIPTION
Using the `DIR/*` format _technically_ works in git. But what this is REALLY saying is ignore first-level files in the `DIR` directory. This will cause software that reads the .gitignore file to not ignore stuff like `DIR/app/stuff.js`.

![screenshot 2014-12-11 19 32 28](https://cloud.githubusercontent.com/assets/2192970/5406347/a8cdd674-8177-11e4-9e27-686d036bd2a1.png)

http://stackoverflow.com/a/8783675/1585343
http://git-scm.com/docs/gitignore
