### PR TITLE
use ~ operator on composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,8 @@
   ],
   "require": {
     "php": ">=5.4",
-    "composer/installers": "v1.0.12",
-    "vlucas/phpdotenv": "1.0.9",
+    "composer/installers": "~1.0.12",
+    "vlucas/phpdotenv": "~1.0.9",
     "johnpbloch/wordpress": "4.1.1"
   },
   "extra": {


### PR DESCRIPTION
This commit uses the ~ operator on composer requirements so that composer upgrade grabs the latest bugfixes etc...