### PR TITLE
Autoloader: load plugins on muplugins_loaded

### DIFF
--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Bedrock Autoloader
  * Plugin URI: https://github.com/roots/bedrock/
- * Description: An autoloader that enables standard plugins to be required just like must-use plugins. The autoloaded plugins are included during mu-plugin loading. An asterisk (*) next to the name of the plugin designates the plugins that have been autoloaded.
+ * Description: An autoloader that enables standard plugins to be required just like must-use plugins. The autoloaded plugins are included during the `muplugins_loaded` action. An asterisk (*) next to the name of the plugin designates the plugins that have been autoloaded.
  * Version: 1.0.0
  * Author: Roots
  * Author URI: https://roots.io/
@@ -32,7 +32,7 @@ class Autoloader {
       add_filter('show_advanced_plugins', array($this, 'showInAdmin'), 0, 2); // Admin only filter.
     }
 
-    $this->loadPlugins();
+    add_action('muplugins_loaded', [$this, 'loadPlugins'], 0);
   }
 
   /**


### PR DESCRIPTION
Directly calling `loadPlugins` wasn't correct since all the autoloaded plugins would be loaded when the Autoloader was loaded. If another muplugin happened to be loaded before it, it wouldn't have access to the
rest of the plugins.

Using the `muplugins_loaded` action ensures consistency. All the autoloaded plugins will be guaranteed to be loaded at the same part of the loading process now and have access to all regular muplugins.