### PR TITLE
Add dd() function to dev environment

### DIFF
--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -11,3 +11,13 @@ define('WP_SITEURL', getenv('WP_SITEURL'));
 define('SAVEQUERIES', true);
 define('WP_DEBUG', true);
 define('SCRIPT_DEBUG', true);
+
+if (!function_exists('dd')) {
+  function dd() {
+    $xdebug = ini_get('xdebug.overload_var_dump');
+    $args = (array) func_get_args();
+    echo $xdebug ? '' : '<pre>';
+    echo call_user_func_array('_log', $args);
+    die($xdebug ? '' : '</pre>');
+  }
+}


### PR DESCRIPTION
Laravel has a function called `dd()` which is short for "dump and die." This is my take on it for us WordPress users. I put it in `development.php` because it shouldn't really be used in any other setting.