### PR TITLE
Cleaner syntax

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -15,7 +15,7 @@ Dotenv::required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL'])
  * Set up our global environment constant and load its config first
  * Default: development
  */
-define('WP_ENV', getenv('WP_ENV') ? getenv('WP_ENV') : 'development');
+define('WP_ENV', getenv('WP_ENV') ?: 'development');
 
 $env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
 
@@ -42,10 +42,10 @@ define('WP_CONTENT_URL', WP_HOME . CONTENT_DIR);
 define('DB_NAME', getenv('DB_NAME'));
 define('DB_USER', getenv('DB_USER'));
 define('DB_PASSWORD', getenv('DB_PASSWORD'));
-define('DB_HOST', getenv('DB_HOST') ? getenv('DB_HOST') : 'localhost');
+define('DB_HOST', getenv('DB_HOST') ?: 'localhost');
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
-$table_prefix = getenv('DB_PREFIX') ? getenv('DB_PREFIX') : 'wp_';
+$table_prefix = getenv('DB_PREFIX') ?: 'wp_';
 
 /**
  * Authentication Unique Keys and Salts

--- a/config/application.php
+++ b/config/application.php
@@ -9,7 +9,7 @@ if (file_exists($root_dir . '/.env')) {
   Dotenv::load($root_dir);
 }
 
-Dotenv::required(array('DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL'));
+Dotenv::required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
 
 /**
  * Set up our global environment constant and load its config first


### PR DESCRIPTION
Couple of minor tweaks here in `application.php`.

Using short array syntax per style guidelines, as well as short ternary syntax for getenv defaults.

Checked with codesniffer.