### PR TITLE
PSR-0 Deprecation: use PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "generate-salts": true
   },
   "autoload": {
-    "psr-0": {"Roots\\Bedrock\\Installer": "scripts"}
+    "psr-4": {"Roots\\Bedrock\\": "scripts/Roots/Bedrock"}
   },
   "scripts": {
     "post-root-package-install": ["Roots\\Bedrock\\Installer::addSalts"]


### PR DESCRIPTION
PSR-0 is deprecated:
https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md

We should use PSR-4, the recommended alternative.