### PR TITLE
Only call required if .env file exists

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -8,9 +8,8 @@ $webroot_dir = $root_dir . '/web';
 $dotenv = new Dotenv\Dotenv($root_dir);
 if (file_exists($root_dir . '/.env')) {
   $dotenv->load();
+  $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
 }
-
-$dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
 
 /**
  * Set up our global environment constant and load its config first


### PR DESCRIPTION
Fixes a crash in Dotenv required which expects a valid Loader instance in $this->loader in `vendor/vlucas/phpdotenv/src/Dotenv.php` on line `83`