### PR TITLE
If path is not the current directory then correct it.

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -1,5 +1,8 @@
 <?php
 
+// Bedrock will load paths relative to this script make sure we're in the same directory
+chdir(__DIR__);
+
 // WordPress view bootstrapper
 define('WP_USE_THEMES', true);
 require(__DIR__ . '/wp/wp-blog-header.php');


### PR DESCRIPTION
When debugging it's helpful to launch bedrock from different folder paths. Specifically when using Cloud9 IDE. Bedrock will fail to reference the correct paths if it is launched elsewhere. This fixes the issue.