### PR TITLE
Simplify gitignore for mu-plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,10 @@
 # Application
 web/app/plugins/*
 !web/app/plugins/.gitkeep
-web/app/mu-plugins/*
-!web/app/mu-plugins/.gitkeep
+web/app/mu-plugins/*/
 web/app/upgrade
 web/app/uploads/*
 !web/app/uploads/.gitkeep
-!web/app/mu-plugins/disallow-indexing.php
-!web/app/mu-plugins/register-theme-directory.php
-!web/app/mu-plugins/bedrock-autoloader.php
 
 # WordPress
 web/wp


### PR DESCRIPTION
In my experience, I haven't had a situation where I had a mu-plugin in the root of the mu-plugins directory that I would want to ignore as these are almost always self-created.  Sub directories, however, are usually ok to ignore as a rule, as those can be packages, which should be ignored.  Since packages can't be installed into the root, without some kind of custom installer, it makes more sense I think to have it like this.  Of course there could be sub-directories there that you may not want to ignore, and then in those situations, it makes perfect sense to add an exception in the ignore.

From a workflow perspective, it seems unintuitive to me that if I want to add an mu-plugin of my own in the root, that I should then need to add it to the gitignore whitelist.

**TL;DR**
This changes the `.gitignore` for the mu-plugins directory from ignoring everything below `/*` and then explicitly un-ignoring `!` specific mu-plugin files, to just ignoring sub-directories instead `/*/`.