### PR TITLE
Set DISABLE_WP_CRON from env var

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -63,7 +63,7 @@ define('NONCE_SALT', getenv('NONCE_SALT'));
  * Custom Settings
  */
 define('AUTOMATIC_UPDATER_DISABLED', true);
-define('DISABLE_WP_CRON', true);
+define('DISABLE_WP_CRON', getenv('DISABLE_WP_CRON') ?: false);
 define('DISALLOW_FILE_EDIT', true);
 
 /**


### PR DESCRIPTION
This allows better control via configuration management like Trellis.

Also change the default to `false`. This setting requires external server configuration for cron to work and since Bedrock is a standalone boilerplate, we shouldn't require that by default.