### PR TITLE
Remove unnecessary slash from $root_dir

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -1,5 +1,5 @@
 <?php
-$root_dir = dirname(__DIR__);
+$root_dir = rtrim(dirname(__DIR__), '/');
 $webroot_dir = $root_dir . '/web';
 
 /**


### PR DESCRIPTION
Fix for environments where `dirname(__DIR__)` returns just a slash `/` which makes `$webroot_dir` = `//web`.

A real life example with which I had to deal recently:

Plugin defines its URL by creating a path:

```
$plugin_dir = dirname(__FILE__); // /web/app/plugins/example-plugin
```

Then it creates an URL like this:

```
$plugin_url = str_replace(
	array( WP_CONTENT_DIR, WP_PLUGIN_DIR ),
	array( WP_CONTENT_URL, WP_PLUGIN_URL ),
	$plugin_dir;
);
```

What we have now is:

`$plugin_dir` = `/web/app/plugins/example-plugin`

`WP_CONTENT_DIR` = `//web/app`,
 `WP_PLUGIN_DIR` = `//web/app/plugins`

`WP_CONTENT_URL` = `http://www.example.com/app`, 
`WP_PLUGIN_URL` = `http://www.example.com/app/plugins`

In this case `str_replace` doesn't work as expected, URL doesn't exist: 
`$plugin_url` = `/web/app/plugins/example-plugin/`.

It would work with fixed $root_dir:

`$plugin_dir` = `/web/app/plugins/example-plugin`

`WP_CONTENT_DIR` = `/web/app`, 
`WP_PLUGIN_DIR` = `/web/app/plugins`

`WP_CONTENT_URL` = `http://www.example.com/app`, 
`WP_PLUGIN_URL` = `http://www.example.com/app/plugins`

`/web/app/plugins/example-plugin` -> `http://www.example.com/app/plugins/example-plugin`