### PR TITLE
In the autoloader, remove argument from call to get_mu_plugins()

### DIFF
--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -95,7 +95,7 @@ class Autoloader {
     require_once(ABSPATH . 'wp-admin/includes/plugin.php');
 
     self::$auto_plugins = get_plugins(self::$relative_path);
-    self::$mu_plugins   = get_mu_plugins(self::$relative_path);
+    self::$mu_plugins   = get_mu_plugins();
     $plugins            = array_diff_key(self::$auto_plugins, self::$mu_plugins);
     $rebuild            = !is_array(self::$cache['plugins']);
     self::$activated    = ($rebuild) ? $plugins : array_diff_key($plugins, self::$cache['plugins']);


### PR DESCRIPTION
`get_mu_plugins()` is being called with an argument, but this function does not accept one. I checked back to 3.0.0 when it was introduced and it doesn't appear this API call ever accepted an argument.

This PR simply removes the argument from the call for clarity's sake.