### PR TITLE
Used nested WP_HOME in WP_SITEURL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ DB_HOST=database_host
 
 WP_ENV=development
 WP_HOME=http://example.com
-WP_SITEURL=http://example.com/wp
+WP_SITEURL=${WP_HOME}/wp
 
 # Generate your keys here: https://api.wordpress.org/secret-key/1.1/salt/
 AUTH_KEY=generateme


### PR DESCRIPTION
Since v2.0, Dotenv has allowed for [nested variables](https://github.com/vlucas/phpdotenv/blob/91064290f5b53a09bdff1b939d7f69fb0e7531b5/README.md#nesting-variables).

Thoughts on using this?  It seems kind of silly to have to duplicate manually.

An alternative might be adding a conditional in `config/application.php` where, if `WP_SITEURL` isn't defined, it defaults to `WP_HOME/wp`, and then we could `dotenv->require()` one less env var at the same time?