### PR TITLE
env variables are strings

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -63,7 +63,7 @@ define('NONCE_SALT', getenv('NONCE_SALT'));
  * Custom Settings
  */
 define('AUTOMATIC_UPDATER_DISABLED', true);
-define('DISABLE_WP_CRON', getenv('DISABLE_WP_CRON') ?: false);
+define('DISABLE_WP_CRON', getenv('DISABLE_WP_CRON') == 'true');
 define('DISALLOW_FILE_EDIT', true);
 
 /**


### PR DESCRIPTION
In Bash, environment variable is always a string (which is what getenv() returns).
Because of the way this constant is checked in WP:
`if ( defined('DISABLE_WP_CRON') && DISABLE_WP_CRON )`,
setting `DISABLE_WP_CRON=false` would resolve to true.
This approach should be more predictable