### PR TITLE
Add BEDROCK_SECURE_ENV env variable

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -71,6 +71,29 @@ define('AUTOMATIC_UPDATER_DISABLED', true);
 define('DISABLE_WP_CRON', env('DISABLE_WP_CRON') ?: false);
 define('DISALLOW_FILE_EDIT', true);
 
+if (true === env('BEDROCK_SECURE_ENV')) {
+  // If BEDROCK_SECURE_ENV is set to true, then unset all the security sensitive variables after they are used
+  bedrock_clear_env('DB_NAME');
+  bedrock_clear_env('DB_USER');
+  bedrock_clear_env('DB_PASSWORD');
+  bedrock_clear_env('DB_HOST');
+  bedrock_clear_env('DB_PREFIX');
+  bedrock_clear_env('AUTH_KEY');
+  bedrock_clear_env('SECURE_AUTH_KEY');
+  bedrock_clear_env('LOGGED_IN_KEY');
+  bedrock_clear_env('NONCE_KEY');
+  bedrock_clear_env('AUTH_SALT');
+  bedrock_clear_env('SECURE_AUTH_SALT');
+  bedrock_clear_env('LOGGED_IN_SALT');
+  bedrock_clear_env('NONCE_SALT');
+}
+
+function bedrock_clear_env($var_name) {
+  // Dotenv has a similar function Dotenv\Loader\clearEnvironmentVariable() but it is not exposed
+  putenv($var_name);
+  unset($_ENV[$var_name], $_SERVER[$var_name]);
+}
+
 /**
  * Bootstrap WordPress
  */


### PR DESCRIPTION
If set to true then all of the secure variables are unset after they are used for configuring WordPress
Disabled by default, so it must be enabled to have any effect

I really like bedrock, but I dislike the idea of using environment variables for secure things. I've seen far too many plugins that allow unrestricted access to the phpinfo() function which would give enough information away for someone to completely takeover a site.