### PR TITLE
Updated composer to allow non-https connections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "forum": "https://discourse.roots.io/category/bedrock"
   },
   "config": {
-    "preferred-install": "dist"
+    "preferred-install": "dist",
+    "secure-http": false
   },
   "repositories": [
     {


### PR DESCRIPTION
WPackagist can not use https-connections right now. 
In the mean time, this could be a fix.

Cfr: https://github.com/roots/bedrock/issues/241