### PR TITLE
Instruct users to quote salts in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,12 +7,12 @@ WP_ENV=development
 WP_HOME=http://example.com
 WP_SITEURL=${WP_HOME}/wp
 
-# Generate your keys here: https://api.wordpress.org/secret-key/1.1/salt/
-AUTH_KEY=generateme
-SECURE_AUTH_KEY=generateme
-LOGGED_IN_KEY=generateme
-NONCE_KEY=generateme
-AUTH_SALT=generateme
-SECURE_AUTH_SALT=generateme
-LOGGED_IN_SALT=generateme
-NONCE_SALT=generateme
+# Generate your keys here (wrap them in quotes): https://api.wordpress.org/secret-key/1.1/salt/
+AUTH_KEY='generateme'
+SECURE_AUTH_KEY='generateme'
+LOGGED_IN_KEY='generateme'
+NONCE_KEY='generateme'
+AUTH_SALT='generateme'
+SECURE_AUTH_SALT='generateme'
+LOGGED_IN_SALT='generateme'
+NONCE_SALT='generateme'


### PR DESCRIPTION
If we use the Salt function on api.wordpress.org, the keys will usually contain spaces. To avoid the `'Dotenv\Exception\InvalidFileException' with message 'Dotenv values containing spaces must be surrounded by quotes.'`, we should instruct users to quote their keys.