### PR TITLE
Update salt link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ WP_ENV=development
 WP_HOME=http://example.com
 WP_SITEURL=${WP_HOME}/wp
 
-# Generate your keys here (wrap them in quotes): https://api.wordpress.org/secret-key/1.1/salt/
+# Generate your keys here (wrap them in quotes): https://wordplate.github.io/salt/
 AUTH_KEY='generateme'
 SECURE_AUTH_KEY='generateme'
 LOGGED_IN_KEY='generateme'


### PR DESCRIPTION
Replaced the default salt link with a one that works better for dotenv files. Now developers just need to copy and paste the environment salt keys to their `.env` file.