### PR TITLE
Allow DB_CHARSET to be set in environment

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -52,7 +52,7 @@ define('DB_NAME', env('DB_NAME'));
 define('DB_USER', env('DB_USER'));
 define('DB_PASSWORD', env('DB_PASSWORD'));
 define('DB_HOST', env('DB_HOST') ?: 'localhost');
-define('DB_CHARSET', 'utf8mb4');
+define('DB_CHARSET', env('DB_CHARSET') ?: 'utf8mb4');
 define('DB_COLLATE', '');
 $table_prefix = env('DB_PREFIX') ?: 'wp_';
 


### PR DESCRIPTION
We'll still use utf8mb4 as a default if DB_CHARSET is undefined, but we allow users to define their own charset. Sadly, some MySQL installations out there in the wild still don't support utf8mb4...