### PR TITLE
Isolate scope for autoloaded mu-plugins

### DIFF
--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -73,7 +73,7 @@ class Autoloader
         $this->countPlugins();
 
         foreach (self::$cache['plugins'] as $plugin_file => $plugin_info) {
-            include_once(WPMU_PLUGIN_DIR . '/' . $plugin_file);
+            load($plugin_file);
         }
 
         $this->pluginHooks();
@@ -193,6 +193,15 @@ class Autoloader
 
         return self::$count;
     }
+}
+
+/**
+ * Load an mu-plugin file
+ *
+ * @param  string $plugin_file  The plugin file path as returned by `get_plugins()`
+ */
+function load() {
+    include_once(WPMU_PLUGIN_DIR . '/' . func_get_args()[0]);
 }
 
 new Autoloader();

--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -72,9 +72,9 @@ class Autoloader
         $this->validatePlugins();
         $this->countPlugins();
 
-        foreach (self::$cache['plugins'] as $plugin_file => $plugin_info) {
-            load($plugin_file);
-        }
+        array_map(static function () {
+            include_once(WPMU_PLUGIN_DIR . '/' . func_get_args()[0]);
+        }, array_keys(self::$cache['plugins']));
 
         $this->pluginHooks();
     }
@@ -193,15 +193,6 @@ class Autoloader
 
         return self::$count;
     }
-}
-
-/**
- * Load an mu-plugin file
- *
- * @param  string $plugin_file  The plugin file path as returned by `get_plugins()`
- */
-function load() {
-    include_once(WPMU_PLUGIN_DIR . '/' . func_get_args()[0]);
 }
 
 new Autoloader();


### PR DESCRIPTION
As it is, the scope for an autoloaded mu-plugin is unnecessarily polluted.

I'm using this simple test plugin as an example here:

```php
// web/app/mu-plugins/test/test.php
<?php
/**
 * Plugin Name: TEST
 */
var_dump(get_defined_vars());
die;
```

When we run this, we get quite a few results:
```

array(2) {
  ["plugin_info"]=>
  array(11) {
    ["Name"]=>
    string(4) "TEST"
    ["PluginURI"]=>
    string(0) ""
    ["Version"]=>
    string(0) ""
    ["Description"]=>
    string(0) ""
    ["Author"]=>
    string(0) ""
    ["AuthorURI"]=>
    string(0) ""
    ["TextDomain"]=>
    string(0) ""
    ["DomainPath"]=>
    string(0) ""
    ["Network"]=>
    bool(false)
    ["Title"]=>
    string(4) "TEST"
    ["AuthorName"]=>
    string(0) ""
  }
  ["plugin_file"]=>
  string(13) "test/test.php"
}
```
Not only that but if we dump `$this` from our test plugin we get:
```
object(Roots\Bedrock\Autoloader)#125 (0) {
}
```

This PR cleans all this up with a simple function and some php 5.4 array dereferencing, providing a clean slate for each plugin loaded.  

#### The result after the proposed changes here when running our test:

`var_dump(get_defined_vars())`
```
array(0) {
}
```

`var_dump($this)`
> Notice: Undefined variable: this


Booyakasha.