### PR TITLE
Ignore irrelevant files when installing via Composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.github export-ignore
+/.gitattributes export-ignore
+/.editorconfig export-ignore
+/.travis.yml export-ignore
+/phpcs.xml export-ignore


### PR DESCRIPTION
When composer installs a stable version of a project it will use the
`dist` as the default.

This `.gitattributes` file excludes several files and directories from
being exported to the dist zip file.

This should make it easier for users to get started, since they don't
have to "clean up" the generated directory.