### PR TITLE
Add Gitlab CI tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,28 @@
+
+variables:
+  COMPOSER_HOME: composer-home
+
+cache:
+  key: "$CI_BUILD_NAME"
+  paths:
+    - composer-home/
+    - vendor/
+
+before_script:
+  - echo 'memory_limit=1024M' > /usr/local/etc/php/conf.d/memory_limit.ini
+  - composer install -o --prefer-dist --no-interaction
+
+test:5.5:
+  image: danieldent/php-5.5-composer
+  script:
+    - composer test
+
+test:5.6:
+  image: danieldent/php-5.6-composer
+  script:
+    - composer test
+
+test:7.0:
+  image: danieldent/php-7.0-composer
+  script:
+    - composer test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,11 +12,6 @@ before_script:
   - echo 'memory_limit=1024M' > /usr/local/etc/php/conf.d/memory_limit.ini
   - composer install -o --prefer-dist --no-interaction
 
-test:5.5:
-  image: danieldent/php-5.5-composer
-  script:
-    - composer test
-
 test:5.6:
   image: danieldent/php-5.6-composer
   script:


### PR DESCRIPTION
This runs the same tests suite as the existing .travis.yml file. Users who fork this repo to a Gitlab server will be able to continue to use CI on their private fork. 

If desired, it would be easy to setup a mirror of the project on gitlab.com - that would make it so that the README could include a Gitlab build badge example.