### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,5 @@ vendor/*
 node_modules
 
 # Vagrant
-bin
+bin/
 .vagrant


### PR DESCRIPTION
The `bin` is covered by `vendor/*`. Correct template is `bin/`