### PR TITLE
Modular configuration

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -1,10 +1,15 @@
 <?php
 
 /** @var string Directory containing all of the site's files */
-$root_dir = dirname(__DIR__);
+define('BEDROCK_ROOT_DIR', dirname(__DIR__));
 
 /** @var string Document Root */
-$webroot_dir = $root_dir . '/web';
+define('BEDROCK_WEB_ROOT_DIR', BEDROCK_ROOT_DIR . '/web');
+
+/** @var string Absolute path to the core WordPress directory */
+if (!defined('ABSPATH')) {
+    define('ABSPATH', BEDROCK_WEB_ROOT_DIR . '/wp/');
+}
 
 /**
  * Expose global env() function from oscarotero/env
@@ -12,72 +17,9 @@ $webroot_dir = $root_dir . '/web';
 Env::init();
 
 /**
- * Use Dotenv to set required environment variables and load .env file in root
+ * Load configuration modules
  */
-$dotenv = new Dotenv\Dotenv($root_dir);
-if (file_exists($root_dir . '/.env')) {
-    $dotenv->load();
-    $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
+foreach (glob(__DIR__ . '/modules/*.php') as $file) {
+    include $file;
 }
-
-/**
- * Set up our global environment constant and load its config first
- * Default: development
- */
-define('WP_ENV', env('WP_ENV') ?: 'development');
-
-$env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
-
-if (file_exists($env_config)) {
-    require_once $env_config;
-}
-
-/**
- * URLs
- */
-define('WP_HOME', env('WP_HOME'));
-define('WP_SITEURL', env('WP_SITEURL'));
-
-/**
- * Custom Content Directory
- */
-define('CONTENT_DIR', '/app');
-define('WP_CONTENT_DIR', $webroot_dir . CONTENT_DIR);
-define('WP_CONTENT_URL', WP_HOME . CONTENT_DIR);
-
-/**
- * DB settings
- */
-define('DB_NAME', env('DB_NAME'));
-define('DB_USER', env('DB_USER'));
-define('DB_PASSWORD', env('DB_PASSWORD'));
-define('DB_HOST', env('DB_HOST') ?: 'localhost');
-define('DB_CHARSET', 'utf8mb4');
-define('DB_COLLATE', '');
-$table_prefix = env('DB_PREFIX') ?: 'wp_';
-
-/**
- * Authentication Unique Keys and Salts
- */
-define('AUTH_KEY', env('AUTH_KEY'));
-define('SECURE_AUTH_KEY', env('SECURE_AUTH_KEY'));
-define('LOGGED_IN_KEY', env('LOGGED_IN_KEY'));
-define('NONCE_KEY', env('NONCE_KEY'));
-define('AUTH_SALT', env('AUTH_SALT'));
-define('SECURE_AUTH_SALT', env('SECURE_AUTH_SALT'));
-define('LOGGED_IN_SALT', env('LOGGED_IN_SALT'));
-define('NONCE_SALT', env('NONCE_SALT'));
-
-/**
- * Custom Settings
- */
-define('AUTOMATIC_UPDATER_DISABLED', true);
-define('DISABLE_WP_CRON', env('DISABLE_WP_CRON') ?: false);
-define('DISALLOW_FILE_EDIT', true);
-
-/**
- * Bootstrap WordPress
- */
-if (!defined('ABSPATH')) {
-    define('ABSPATH', $webroot_dir . '/wp/');
-}
+unset($file);

--- a/config/modules/10-dotenv.php
+++ b/config/modules/10-dotenv.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Use Dotenv to set required environment variables and load .env file in root
+ */
+$dotenv = new Dotenv\Dotenv(BEDROCK_ROOT_DIR);
+if (file_exists(BEDROCK_ROOT_DIR . '/.env')) {
+    $dotenv->load();
+    $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
+}

--- a/config/modules/15-wp-env.php
+++ b/config/modules/15-wp-env.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Set up our global environment constant and load its config first
+ * Default: development
+ */
+define('WP_ENV', env('WP_ENV') ?: 'development');
+
+$env_config = BEDROCK_ROOT_DIR . '/config/environments/' . WP_ENV . '.php';
+
+if (file_exists($env_config)) {
+    require_once $env_config;
+}
+unset($env_config);

--- a/config/modules/20-cron.php
+++ b/config/modules/20-cron.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * WP Cron Configuration
+ */
+define('DISABLE_WP_CRON', env('DISABLE_WP_CRON') ?: false);

--- a/config/modules/20-database.php
+++ b/config/modules/20-database.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Database configuration
+ */
+define('DB_NAME', env('DB_NAME'));
+define('DB_USER', env('DB_USER'));
+define('DB_PASSWORD', env('DB_PASSWORD'));
+define('DB_HOST', env('DB_HOST') ?: 'localhost');
+define('DB_CHARSET', 'utf8mb4');
+define('DB_COLLATE', '');
+$GLOBALS['table_prefix'] = env('DB_PREFIX') ?: 'wp_';

--- a/config/modules/20-lockdown.php
+++ b/config/modules/20-lockdown.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Protect application file integrity from user changes via wp-admin.
+ */
+define('AUTOMATIC_UPDATER_DISABLED', true);
+define('DISALLOW_FILE_EDIT', true);

--- a/config/modules/20-salts.php
+++ b/config/modules/20-salts.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Authentication Unique Keys and Salts
+ */
+define('AUTH_KEY', env('AUTH_KEY'));
+define('SECURE_AUTH_KEY', env('SECURE_AUTH_KEY'));
+define('LOGGED_IN_KEY', env('LOGGED_IN_KEY'));
+define('NONCE_KEY', env('NONCE_KEY'));
+define('AUTH_SALT', env('AUTH_SALT'));
+define('SECURE_AUTH_SALT', env('SECURE_AUTH_SALT'));
+define('LOGGED_IN_SALT', env('LOGGED_IN_SALT'));
+define('NONCE_SALT', env('NONCE_SALT'));

--- a/config/modules/20-urls.php
+++ b/config/modules/20-urls.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * URLs
+ */
+define('WP_HOME', env('WP_HOME'));
+define('WP_SITEURL', env('WP_SITEURL'));

--- a/config/modules/25-content-directory.php
+++ b/config/modules/25-content-directory.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Custom Content Directory
+ */
+define('CONTENT_DIR', '/app');
+define('WP_CONTENT_DIR', BEDROCK_WEB_ROOT_DIR . CONTENT_DIR);
+define('WP_CONTENT_URL', WP_HOME . CONTENT_DIR);


### PR DESCRIPTION
This PR splits Bedrock's application.php into it's logical modular components of configuration, aimed to make Bedrock more extensible and easier to maintain.

Modeled after conventions seen in *nix `conf.d` type directories, configuration modules are just php files, named in a way which controls the load order, similar to action/filter priorities.

![image](https://cloud.githubusercontent.com/assets/1621608/17457382/9bc487ea-5c07-11e6-9a18-46f03e1181b6.png)

This makes it so modules of configuration are more reusable between projects, as well as making it easier for sites to "sync" with future changes to Bedrock core.  This has been difficult at times on projects with a customized `application.php`.

For example, I often add my own logging configuration to the application.php.  With a modular configuration, this could be as simple as adding a `config/modules/0-logging.php` file; no need to change anything related to Bedrock core.

An important change which makes this PR possible, is the introduction of new constants `BEDROCK_ROOT_DIR` and `BEDROCK_WEB_ROOT_DIR`, which not only replace the need for their respective temporary variables in the various configuration modules, but can be useful in other cases with your own application code.

Eg: Loading a file that is in a root directory from an mu-plugin:

```
require_once BEDROCK_ROOT_DIR . '/bootstrap/app.php';
```

Another byproduct is that `application.php` and other "core" configuration modules will most likely not need to be changed and custom user configuration can simply be another drop-in module.

Any required temporary variables are also unset now where possible to prevent unnecessary leakage into the global scope.

**A note about the usage of `glob()`**

This change leverages the [glob()](http://php.net/manual/en/function.glob.php) function to read in the files from the new `config/modules` directory.  Some might be concerned about this as an unnecessary performance cost on every request, but from my research it's an amount of insignificant time.

There is an interesting report on it [here](http://jameshalsall.co.uk/posts/glob-performance-for-finding-files-in-php) although it is roughly 3 years old (read: way before PHP 7).  Even at this time, with a set of thousands of files of mixed types, globbing all php files took roughly a _half of a hundredth of a second_.  You can actually clone the repo and run their benchmarks yourself quite easily.

Anyways, this could enhanced for performance with caching if needed, it just seems unnecessary and would come at the cost of increased complexity.
