### PR TITLE
Use site transients for saving mu-plugins

### DIFF
--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -112,7 +112,7 @@ class Autoloader
      */
     private function checkCache()
     {
-        $cache = get_site_option('bedrock_autoloader');
+        $cache = get_site_transient('bedrock_autoloader');
 
         if ($cache === false) {
             $this->updateCache();
@@ -138,7 +138,7 @@ class Autoloader
         self::$activated    = ($rebuild) ? $plugins : array_diff_key($plugins, self::$cache['plugins']);
         self::$cache        = array('plugins' => $plugins, 'count' => $this->countPlugins());
 
-        update_site_option('bedrock_autoloader', self::$cache);
+        set_site_transient('bedrock_autoloader', self::$cache);
     }
 
     /**


### PR DESCRIPTION
Since the mu-plugins list should be considered a cache we should use transients for saving the plugin list.
