### PR TITLE
Production environment by default

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -22,9 +22,9 @@ if (file_exists($root_dir . '/.env')) {
 
 /**
  * Set up our global environment constant and load its config first
- * Default: development
+ * Default: production
  */
-define('WP_ENV', env('WP_ENV') ?: 'development');
+define('WP_ENV', env('WP_ENV') ?: 'production');
 
 $env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
 


### PR DESCRIPTION
In my enormous amount of spare time, I've been working on a side project where I'm working on integrating best practices throughout a WP project.

It seems like a more sensible default for a site would be to default to production, rather than development. Development has all errors being displayed, amongst some other things. It's rather pedantic, but if a user forgets to set this for some reason, the safer option would be production rather than development