### PR TITLE
Relax version constraint for WordPress core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "php": ">=5.6",
     "composer/installers": "~1.0.12",
     "vlucas/phpdotenv": "^2.0.1",
-    "johnpbloch/wordpress": "4.7.2",
+    "johnpbloch/wordpress": "^4.7.2",
     "oscarotero/env": "^1.0",
     "roots/wp-password-bcrypt": "1.0.0"
   },


### PR DESCRIPTION
Users should be able to apply minor and patch updates to core with a simple `composer update`