### PR TITLE
Ignore CHANGELOG.md on composer create command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 /.editorconfig export-ignore
 /.travis.yml export-ignore
 /phpcs.xml export-ignore
+/CHANGELOG.md


### PR DESCRIPTION
Composer can ignore this file by reading .gitattributes