### PR TITLE
Auto create .env on composer create

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See a complete working example in the [roots-example-project.com repo](https://g
 
   `composer create-project roots/bedrock your-project-folder-name`
 
-2. Copy `.env.example` to `.env` and update environment variables:
+2. Update environment variables in `.env`  file:
   * `DB_NAME` - Database name
   * `DB_USER` - Database user
   * `DB_PASSWORD` - Database password

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,9 @@
     "wordpress-install-dir": "web/wp"
   },
   "scripts": {
+    "post-root-package-install": [
+      "php -r \"copy('.env.example', '.env');\""
+    ],
     "test": [
       "vendor/bin/phpcs"
     ]


### PR DESCRIPTION
We know that everyone going to copy ```.env.example``` and create a ```.env``` so why not auto create this file.
This script will run only when someone​ use ```composer create``` command.
