### PR TITLE
Remove /wp/ from no wp-admin/wp-includes URIs from site_url()

### DIFF
--- a/web/app/mu-plugins/site-url-fix.php
+++ b/web/app/mu-plugins/site-url-fix.php
@@ -1,0 +1,26 @@
+<?php
+/*
+Plugin Name:  Site URL fix
+Plugin URI:   https://roots.io/bedrock/
+Description:  Remove /wp/ if the URL doesn't contain /wp-includes/ or /wp-admin/
+Version:      1.0.0
+Author:       Roots
+Author URI:   https://roots.io/
+License:      MIT License
+*/
+
+namespace Roots\Bedrock;
+
+if (!is_blog_installed()) {
+    return;
+}
+
+function site_url_fix($site_url)
+{
+    if (preg_match('/wp\/(?!wp-(includes|admin))/', $site_url)) {
+        $site_url = str_replace('/wp', '', $site_url);
+    }
+
+    return $site_url;
+}
+add_filter('site_url', '\Roots\Bedrock\site_url_fix', 99);


### PR DESCRIPTION
Anyone have understood well the difference between home_url() and site_url() yet.

So, the results is that with bedrock (in this case) often I have to see URIs on frontend like that: `mysite.com/wp/page` instead of `mysite.com/page`

Many plugins still use site_url() instead of home_url() for the URLs and you will see may frontend URLs with `/wp`.

I thought: the `/wp` is necessary only because of the folders `wp-includes` and `wp-admin` are inside the `wp` folder. So, my solution is to add a mu-plugin that remove the `/wp` part from all URLs passed from `site_url` that don't have `wp-admin` or `wp-includes` part and remove the `/wp` part.

It seems work well. Do you have some contraindication about this that I'm missing?

I hope the explanation is clear for you :)