### PR TITLE
✨ Add support for wp server

### DIFF
--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,1 +1,2 @@
 path: web/wp
+docroot: web


### PR DESCRIPTION
Per issue #321

Running `wp server` will now successfully kick off the WP-CLI server.