### PR TITLE
Check if WP_ENV is defined in disallow-indexing

### DIFF
--- a/web/app/mu-plugins/disallow-indexing.php
+++ b/web/app/mu-plugins/disallow-indexing.php
@@ -9,6 +9,6 @@ Author URI:   https://roots.io/
 License:      MIT License
 */
 
-if (WP_ENV !== 'production' && !is_admin()) {
+if (defined('WP_ENV') && WP_ENV !== 'production' && !is_admin()) {
     add_action('pre_option_blog_public', '__return_zero');
 }


### PR DESCRIPTION
was talking to a dev who used bedrock in development but not in production. but they inadvertently kept the mu-plugin to disable indexing by search engines. oops.

with this pr, the plugin will have no effect if `WP_ENV` isn't defined