### PR TITLE
Set new default WP_POST_REVISIONS for production environment

### DIFF
--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -5,3 +5,5 @@ define('WP_DEBUG_DISPLAY', false);
 define('SCRIPT_DEBUG', false);
 /** Disable all file modifications including updates and update notifications */
 define('DISALLOW_FILE_MODS', true);
+/** Limit number of revisions saved */
+define('WP_POST_REVISIONS', 10);


### PR DESCRIPTION
By default WordPress saves every post revision. Over time this causes the database to grow necessary large. Even when using a few custom fields per post the `wp_postmeta` table can easily get to + 100.000 rows in a year. This causes slow performance when joining the postmeta table.

I always limit the number of revisions by setting `WP_POST_REVISIONS` to a reasonable number in production environments. I think it's a good idea to add this variable to `production.php` config so people don't forget about it. I don't think the default to save every revision is so good and it's better to remove this variable if you want the behaviour than to think about adding it to every project (and clean up the database if you forget:). 

Also, atleast in my experience, the WordPress function to "revert" back to older versions is not used much anyway. At least not beyond a couple revisions.

https://codex.wordpress.org/Revisions