### PR TITLE
Remove vendor/.gitkeep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ web/.htaccess
 !.env.example
 
 # Composer
-vendor/*
-!vendor/.gitkeep
+/vendor


### PR DESCRIPTION
Vendor is a generated directory, there is no reason to have a .gitkeep
that immediately gets blown away on the first composer install

This only serves to mess with tools that try to intelligently determine whether
composer needs to be run for the first time