### PR TITLE
Allow defining WP_CONTENT_URL in .env file

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -47,7 +47,7 @@ Config::define('WP_SITEURL', env('WP_SITEURL'));
  */
 Config::define('CONTENT_DIR', '/app');
 Config::define('WP_CONTENT_DIR', $webroot_dir . Config::get('CONTENT_DIR'));
-Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_DIR'));
+Config::define('WP_CONTENT_URL', env('WP_CONTENT_URL') ?: Config::get('WP_HOME') . Config::get('CONTENT_DIR'));
 
 /**
  * DB settings


### PR DESCRIPTION
This is helpful when creating a cookie-free domain to serve static content