### PR TITLE
Fix issue with bedrock_autoloader option

### DIFF
--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -114,7 +114,7 @@ class Autoloader
     {
         $cache = get_site_option('bedrock_autoloader');
 
-        if ($cache === false) {
+        if ($cache === false || (isset($cache['plugins'], $cache['count']) && count($cache['plugins']) !== $cache['count'])) {
             $this->updateCache();
             return;
         }


### PR DESCRIPTION
This fixes an issue where the `bedrock_autoloader` option is set but the number of plugins differs. I ran into this issue when moving a plugin from `plugin` to `mu-plugin` and deploying to a remote server. 

I haven't been able to recreate this in a reliable way but having ran into this issue a couple of times on different servers I figured I'd propose my fix.

Basically $cache will not evaluate to `false` because it will be set to an array looking like this:

```
array(
'plugins' => array(),
'count' => 0,
);
```

This fixed it for me.

I created the issue in the wrong project. And instead of spamming new issue here you can read my original issue on the Trellis-project https://github.com/roots/trellis/issues/1022.

If you want me to open issue here anyway I can do it.