### PR TITLE
Ignore wp-cli.local.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ web/.htaccess
 
 # Composer
 /vendor
+
+# WP-CLI
+wp-cli.local.yml


### PR DESCRIPTION
ref https://make.wordpress.org/cli/handbook/config/

this seems to make sense.

we might be adding something to trellis that automatically generates a `wp-cli.local.yml` file that sets up a `wp @vagrant` alias for local dev (props @QWp6t)