### PR TITLE
Add PHP 7.3 to Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: php
 php:
+  - 7.3
   - 7.2
   - 7.1
   - 7.0


### PR DESCRIPTION
Looks like it's using a release candidate of 7.3 tho:

https://travis-ci.com/knowler/bedrock/jobs/164556460