### PR TITLE
Detect HTTPS if wordpress is behind a reverse proxy

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -95,6 +95,10 @@ if (file_exists($env_config)) {
     require_once $env_config;
 }
 
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+    $_SERVER['HTTPS'] = 'on';
+}
+
 Config::apply();
 
 /**

--- a/config/application.php
+++ b/config/application.php
@@ -93,7 +93,7 @@ ini_set('display_errors', 0);
  * Allow WordPress to detect HTTPS when used behind a reverse proxy or a load balancer
  * See https://codex.wordpress.org/Function_Reference/is_ssl#Notes
  */
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
     $_SERVER['HTTPS'] = 'on';
 }
 

--- a/config/application.php
+++ b/config/application.php
@@ -89,14 +89,18 @@ Config::define('WP_DEBUG_DISPLAY', false);
 Config::define('SCRIPT_DEBUG', false);
 ini_set('display_errors', 0);
 
+/**
+ * Allow Wordpress to detect HTTPS when used behind a reverse proxy or a load balancer
+ * See https://codex.wordpress.org/Function_Reference/is_ssl#Notes
+ */
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+    $_SERVER['HTTPS'] = 'on';
+}
+
 $env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
 
 if (file_exists($env_config)) {
     require_once $env_config;
-}
-
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
-    $_SERVER['HTTPS'] = 'on';
 }
 
 Config::apply();

--- a/config/application.php
+++ b/config/application.php
@@ -90,7 +90,7 @@ Config::define('SCRIPT_DEBUG', false);
 ini_set('display_errors', 0);
 
 /**
- * Allow Wordpress to detect HTTPS when used behind a reverse proxy or a load balancer
+ * Allow WordPress to detect HTTPS when used behind a reverse proxy or a load balancer
  * See https://codex.wordpress.org/Function_Reference/is_ssl#Notes
  */
 if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {


### PR DESCRIPTION
Hello,

It'd be great if HTTPS would be working behind a reverse proxy, which is very common when using a PaaS or a WAF, or any decent cloud providers.

https://codex.wordpress.org/Function_Reference/is_ssl#Notes

Since it's a condition, it does not harm existing wordpress installations.