### PR TITLE
Allow to use a database DSN instead of all the database variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@ DB_NAME=database_name
 DB_USER=database_user
 DB_PASSWORD=database_password
 
+# Or you can use a DSN (database source name) 
+# In this case you can leave empty variables DB_NAME, DB_USER, DB_PASSWORD, DB_HOST 
+# DATABASE_URL=mysql://database_user:database_password@database_host:database_port/database_name
+
 # Optional variables
 # DB_HOST=localhost
 # DB_PREFIX=wp_

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
     $ composer create-project roots/bedrock
     ```
 2. Update environment variables in the `.env` file:
-  * `DB_NAME` - Database name
-  * `DB_USER` - Database user
-  * `DB_PASSWORD` - Database password
-  * `DB_HOST` - Database host
+  * Database variables
+    * `DB_NAME` - Database name
+    * `DB_USER` - Database user
+    * `DB_PASSWORD` - Database password
+    * `DB_HOST` - Database host
+    * You can also use a variable `DATABASE_URL` instead of using all the database variables above, that contains a DSN (ex: `mysql://user:password@127.0.0.1:3306/db_name`)
   * `WP_ENV` - Set to environment (`development`, `staging`, `production`)
   * `WP_HOME` - Full URL to WordPress home (https://example.com)
   * `WP_SITEURL` - Full URL to WordPress including subdirectory (https://example.com/wp)

--- a/config/application.php
+++ b/config/application.php
@@ -62,7 +62,7 @@ if (true === $hasDsn) {
 
 Config::define('DB_NAME', $hasDsn ? $dbName : env('DB_NAME'));
 Config::define('DB_USER', $hasDsn ? $databaseDsn['user'] : env('DB_USER'));
-Config::define('DB_PASSWORD', $hasDsn ? $databaseDsn['pass'] : env('DB_PASSWORD'));
+Config::define('DB_PASSWORD', $hasDsn ? ($databaseDsn['pass'] ?? null) : env('DB_PASSWORD'));
 Config::define('DB_HOST', $hasDsn ? $dbHost : env('DB_HOST') ?: 'localhost');
 Config::define('DB_CHARSET', 'utf8mb4');
 Config::define('DB_COLLATE', '');

--- a/config/application.php
+++ b/config/application.php
@@ -57,7 +57,7 @@ $hasDsn = env('DATABASE_URL') !== null ? true : false;
 if (true === $hasDsn) {
     $databaseDsn = parse_url(env('DATABASE_URL'));
     $dbName = substr($databaseDsn['path'], 1);
-    $dbHost = $databaseDsn['host'] . ":" . $databaseDsn['port'];
+    $dbHost = isset($databaseDsn['port']) ? $databaseDsn['host'] . ":" . $databaseDsn['port'] : $databaseDsn['host'];
 }
 
 Config::define('DB_NAME', $hasDsn ? $dbName : env('DB_NAME'));

--- a/config/application.php
+++ b/config/application.php
@@ -64,14 +64,14 @@ Config::define('DB_COLLATE', '');
 $table_prefix = env('DB_PREFIX') ?: 'wp_';
 
 if (env('DATABASE_URL')) {
-    $databaseDsn = parse_url(env('DATABASE_URL'));
-    $dbName = substr($databaseDsn['path'], 1);
-    $dbHost = isset($databaseDsn['port']) ? $databaseDsn['host'] . ":" . $databaseDsn['port'] : $databaseDsn['host'];
+    $database_dsn = parse_url(env('DATABASE_URL'));
+    $db_name = substr($database_dsn['path'], 1);
+    $db_host = isset($database_dsn['port']) ? $database_dsn['host'] . ":" . $database_dsn['port'] : $database_dsn['host'];
 
-    Config::define('DB_NAME', $dbName);
-    Config::define('DB_USER', $databaseDsn['user']);
-    Config::define('DB_PASSWORD', $databaseDsn['pass'] ?? null);
-    Config::define('DB_HOST', $dbHost);
+    Config::define('DB_NAME', $db_name);
+    Config::define('DB_USER', $database_dsn['user']);
+    Config::define('DB_PASSWORD', $database_dsn['pass'] ?? null);
+    Config::define('DB_HOST', $db_host);
 }
 
 /**

--- a/config/application.php
+++ b/config/application.php
@@ -29,7 +29,7 @@ if (file_exists($root_dir . '/.env')) {
     $dotenv->load();
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);
     if (!env('DATABASE_URL')) {
-        $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
+        $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD']);
     }
 }
 

--- a/config/application.php
+++ b/config/application.php
@@ -52,21 +52,24 @@ Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_D
 /**
  * DB settings
  */
-$hasDsn = env('DATABASE_URL') !== null ? true : false;
-
-if (true === $hasDsn) {
-    $databaseDsn = parse_url(env('DATABASE_URL'));
-    $dbName = substr($databaseDsn['path'], 1);
-    $dbHost = isset($databaseDsn['port']) ? $databaseDsn['host'] . ":" . $databaseDsn['port'] : $databaseDsn['host'];
-}
-
-Config::define('DB_NAME', $hasDsn ? $dbName : env('DB_NAME'));
-Config::define('DB_USER', $hasDsn ? $databaseDsn['user'] : env('DB_USER'));
-Config::define('DB_PASSWORD', $hasDsn ? ($databaseDsn['pass'] ?? null) : env('DB_PASSWORD'));
-Config::define('DB_HOST', $hasDsn ? $dbHost : env('DB_HOST') ?: 'localhost');
+Config::define('DB_NAME', env('DB_NAME'));
+Config::define('DB_USER', env('DB_USER'));
+Config::define('DB_PASSWORD', env('DB_PASSWORD'));
+Config::define('DB_HOST', env('DB_HOST') ?: 'localhost');
 Config::define('DB_CHARSET', 'utf8mb4');
 Config::define('DB_COLLATE', '');
 $table_prefix = env('DB_PREFIX') ?: 'wp_';
+
+if (env('DATABASE_URL')) {
+    $databaseDsn = parse_url(env('DATABASE_URL'));
+    $dbName = substr($databaseDsn['path'], 1);
+    $dbHost = isset($databaseDsn['port']) ? $databaseDsn['host'] . ":" . $databaseDsn['port'] : $databaseDsn['host'];
+
+    Config::define('DB_NAME', $dbName);
+    Config::define('DB_USER', $databaseDsn['user']);
+    Config::define('DB_PASSWORD', $databaseDsn['pass'] ?? null);
+    Config::define('DB_HOST', $dbHost);
+}
 
 /**
  * Authentication Unique Keys and Salts

--- a/config/application.php
+++ b/config/application.php
@@ -27,7 +27,10 @@ Env::init();
 $dotenv = new Dotenv\Dotenv($root_dir);
 if (file_exists($root_dir . '/.env')) {
     $dotenv->load();
-    $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
+    $dotenv->required(['WP_HOME', 'WP_SITEURL']);
+    if (!env('DATABASE_URL')) {
+        $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'WP_HOME', 'WP_SITEURL']);
+    }
 }
 
 /**

--- a/config/application.php
+++ b/config/application.php
@@ -52,10 +52,18 @@ Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_D
 /**
  * DB settings
  */
-Config::define('DB_NAME', env('DB_NAME'));
-Config::define('DB_USER', env('DB_USER'));
-Config::define('DB_PASSWORD', env('DB_PASSWORD'));
-Config::define('DB_HOST', env('DB_HOST') ?: 'localhost');
+$hasDsn = env('DATABASE_URL') !== null ? true : false;
+
+if (true === $hasDsn) {
+    $databaseDsn = parse_url(env('DATABASE_URL'));
+    $dbName = substr($databaseDsn['path'], 1);
+    $dbHost = $databaseDsn['host'] . ":" . $databaseDsn['port'];
+}
+
+Config::define('DB_NAME', $hasDsn ? $dbName : env('DB_NAME'));
+Config::define('DB_USER', $hasDsn ? $databaseDsn['user'] : env('DB_USER'));
+Config::define('DB_PASSWORD', $hasDsn ? $databaseDsn['pass'] : env('DB_PASSWORD'));
+Config::define('DB_HOST', $hasDsn ? $dbHost : env('DB_HOST') ?: 'localhost');
 Config::define('DB_CHARSET', 'utf8mb4');
 Config::define('DB_COLLATE', '');
 $table_prefix = env('DB_PREFIX') ?: 'wp_';


### PR DESCRIPTION
Hello,

As mentionned on the .README, 
> Bedrock is inspired by the [Twelve-Factor App](http://12factor.net/) methodology

So I was surprised, during my 120+ Wordpress migration plan to add the same snippet over and over again to allow to use a DSN instead of all the random legacy Wordpress variables (`DB_NAME`, `DB_USER`...).

The 12Factor app is clearly in favor of using DSN: https://12factor.net/backing-services.

Also, when using a recent cloud provider, or PaaS provider, the often expose the database through a DSN (since they follow 12Factor App methodology too).

For those reading the PR and who don't know what a [DSN](https://en.wikipedia.org/wiki/Data_source_name) is, it's a string containing the connection information. Ex: 

```
mysql://database_user:database_password@database_host:database_port/database_name
```

So instead of breaking everything and force people to use DSN instead of legacy variables, this PR adds the support of DSN without breaking existing applications.

Basically, it you set a `DATABASE_URL` variable, then the code takes care of parsing the URL to set the correct variables.

I've been running tests on local (where `DATABASE_URL` was not set) and on production (where `DATABASE_URL` was set) with no issues.

I've updated the example and the documentation too.

Tell me what you think about it.

The algorithm takes care of the following DSN variations:
```
mysql://john_doe:password@127.0.0.1:3402/my_awesome_blog
mysql://john_doe:password@127.0.0.1/my_awesome_blog
mysql://john_doe@127.0.0.1/my_awesome_blog
```
