### PR TITLE
Make DSN implementation more uniform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@ DB_USER=database_user
 DB_PASSWORD=database_password
 
 # Optionally, you can use a data source name (DSN)
-# When using a DSN, you can leave DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST empty
-# DB_URL=mysql://database_user:database_password@database_host:database_port/database_name
+# When using a DSN, you can remove the DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST variables
+# DATABASE_URL=mysql://database_user:database_password@database_host:database_port/database_name
 
 # Optional variables
 # DB_HOST=localhost

--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,9 @@ DB_NAME=database_name
 DB_USER=database_user
 DB_PASSWORD=database_password
 
-# Or you can use a DSN (database source name) 
-# In this case you can leave empty variables DB_NAME, DB_USER, DB_PASSWORD, DB_HOST 
-# DATABASE_URL=mysql://database_user:database_password@database_host:database_port/database_name
+# Optionally, you can use a data source name (DSN)
+# When using a DSN, you can leave DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST empty
+# DB_URL=mysql://database_user:database_password@database_host:database_port/database_name
 
 # Optional variables
 # DB_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
 
 ## Installation
 
-1. Create a new project: 
+1. Create a new project:
     ```sh
     $ composer create-project roots/bedrock
     ```
@@ -32,7 +32,7 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
     * `DB_USER` - Database user
     * `DB_PASSWORD` - Database password
     * `DB_HOST` - Database host
-    * You can also use a variable `DATABASE_URL` instead of using all the database variables above, that contains a DSN (ex: `mysql://user:password@127.0.0.1:3306/db_name`)
+    * Optionally, you can define `DB_URL` for using a DSN instead of using the variables above (e.g. `mysql://user:password@127.0.0.1:3306/db_name`)
   * `WP_ENV` - Set to environment (`development`, `staging`, `production`)
   * `WP_HOME` - Full URL to WordPress home (https://example.com)
   * `WP_SITEURL` - Full URL to WordPress including subdirectory (https://example.com/wp)
@@ -40,7 +40,7 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
     * Generate with [wp-cli-dotenv-command](https://github.com/aaemnnosttv/wp-cli-dotenv-command)
     * Generate with [our WordPress salts generator](https://roots.io/salts.html)
 3. Add theme(s) in `web/app/themes/` as you would for a normal WordPress site
-4. Set the document root on your webserver to Bedrock's `web` folder: `/path/to/site/web/` 
+4. Set the document root on your webserver to Bedrock's `web` folder: `/path/to/site/web/`
 5. Access WordPress admin at `https://example.com/wp/wp-admin/`
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
     * `DB_USER` - Database user
     * `DB_PASSWORD` - Database password
     * `DB_HOST` - Database host
-    * Optionally, you can define `DB_URL` for using a DSN instead of using the variables above (e.g. `mysql://user:password@127.0.0.1:3306/db_name`)
+    * Optionally, you can define `DATABASE_URL` for using a DSN instead of using the variables above (e.g. `mysql://user:password@127.0.0.1:3306/db_name`)
   * `WP_ENV` - Set to environment (`development`, `staging`, `production`)
   * `WP_HOME` - Full URL to WordPress home (https://example.com)
   * `WP_SITEURL` - Full URL to WordPress including subdirectory (https://example.com/wp)

--- a/config/application.php
+++ b/config/application.php
@@ -69,7 +69,7 @@ if (env('DATABASE_URL')) {
     Config::define('DB_NAME', substr($dsn->path, 1));
     Config::define('DB_USER', $dsn->user);
     Config::define('DB_PASSWORD', $dsn->pass ?? null);
-    Config::define('DB_HOST', isset($dsn->port) ? $dsn->host . ':' . $dsn->port : $dsn->host);
+    Config::define('DB_HOST', isset($dsn->port) ? "$dsn->host:$dsn->port" : $dsn->host);
 }
 
 /**

--- a/config/application.php
+++ b/config/application.php
@@ -69,7 +69,7 @@ if (env('DATABASE_URL')) {
     Config::define('DB_NAME', substr($dsn->path, 1));
     Config::define('DB_USER', $dsn->user);
     Config::define('DB_PASSWORD', $dsn->pass ?? null);
-    Config::define('DB_HOST', isset($dsn->port) ? "$dsn->host:$dsn->port" : $dsn->host);
+    Config::define('DB_HOST', isset($dsn->port) ? "{$dsn->host}:{$dsn->port}" : $dsn->host);
 }
 
 /**

--- a/config/application.php
+++ b/config/application.php
@@ -28,7 +28,7 @@ $dotenv = Dotenv\Dotenv::create($root_dir);
 if (file_exists($root_dir . '/.env')) {
     $dotenv->load();
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);
-    if (!env('DB_URL')) {
+    if (!env('DATABASE_URL')) {
         $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD']);
     }
 }
@@ -55,16 +55,16 @@ Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_D
 /**
  * DB settings
  */
-Config::define('DB_NAME', env('DB_NAME'));
-Config::define('DB_USER', env('DB_USER'));
-Config::define('DB_PASSWORD', env('DB_PASSWORD'));
+Config::define('DB_NAME', env('DB_NAME') ?? null);
+Config::define('DB_USER', env('DB_USER') ?? null);
+Config::define('DB_PASSWORD', env('DB_PASSWORD') ?? null);
 Config::define('DB_HOST', env('DB_HOST') ?: 'localhost');
 Config::define('DB_CHARSET', 'utf8mb4');
 Config::define('DB_COLLATE', '');
 $table_prefix = env('DB_PREFIX') ?: 'wp_';
 
-if (env('DB_URL')) {
-    $dsn = (object) parse_url(env('DB_URL'));
+if (env('DATABASE_URL')) {
+    $dsn = (object) parse_url(env('DATABASE_URL'));
 
     Config::define('DB_NAME', substr($dsn->path, 1));
     Config::define('DB_USER', $dsn->user);

--- a/config/application.php
+++ b/config/application.php
@@ -28,7 +28,7 @@ $dotenv = Dotenv\Dotenv::create($root_dir);
 if (file_exists($root_dir . '/.env')) {
     $dotenv->load();
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);
-    if (!env('DATABASE_URL')) {
+    if (!env('DB_URL')) {
         $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD']);
     }
 }
@@ -63,15 +63,13 @@ Config::define('DB_CHARSET', 'utf8mb4');
 Config::define('DB_COLLATE', '');
 $table_prefix = env('DB_PREFIX') ?: 'wp_';
 
-if (env('DATABASE_URL')) {
-    $database_dsn = parse_url(env('DATABASE_URL'));
-    $db_name = substr($database_dsn['path'], 1);
-    $db_host = isset($database_dsn['port']) ? $database_dsn['host'] . ":" . $database_dsn['port'] : $database_dsn['host'];
+if (env('DB_URL')) {
+    $dsn = (object) parse_url(env('DB_URL'));
 
-    Config::define('DB_NAME', $db_name);
-    Config::define('DB_USER', $database_dsn['user']);
-    Config::define('DB_PASSWORD', $database_dsn['pass'] ?? null);
-    Config::define('DB_HOST', $db_host);
+    Config::define('DB_NAME', substr($dsn->path, 1));
+    Config::define('DB_USER', $dsn->user);
+    Config::define('DB_PASSWORD', $dsn->pass ?? null);
+    Config::define('DB_HOST', isset($dsn->port) ? $dsn->host . ':' . $dsn->port : $dsn->host);
 }
 
 /**

--- a/config/application.php
+++ b/config/application.php
@@ -55,9 +55,9 @@ Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_D
 /**
  * DB settings
  */
-Config::define('DB_NAME', env('DB_NAME') ?? null);
-Config::define('DB_USER', env('DB_USER') ?? null);
-Config::define('DB_PASSWORD', env('DB_PASSWORD') ?? null);
+Config::define('DB_NAME', env('DB_NAME'));
+Config::define('DB_USER', env('DB_USER'));
+Config::define('DB_PASSWORD', env('DB_PASSWORD'));
 Config::define('DB_HOST', env('DB_HOST') ?: 'localhost');
 Config::define('DB_CHARSET', 'utf8mb4');
 Config::define('DB_COLLATE', '');


### PR DESCRIPTION
Figured I'd propose this change as the implementation is still early so despite being a "breaking change" – very few would be affected.

- Change `DATABASE_URL` to `DB_URL` to remain uniform with the other database variables
- Improve phrasing on the README and `.env.example` DocBlock
- Minor golfing / cleanup on how the DSN is handled in `application.php`
- Apparently editorconfig found some trailing whitespace in the README 🙀 