### PR TITLE
Swap Usage of PHP 7 Null Coalesce Operator 

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -68,7 +68,7 @@ if (env('DATABASE_URL')) {
 
     Config::define('DB_NAME', substr($dsn->path, 1));
     Config::define('DB_USER', $dsn->user);
-    Config::define('DB_PASSWORD', $dsn->pass ?? null);
+    Config::define('DB_PASSWORD', isset($dsn->pass) ? $dsn->pass : null);
     Config::define('DB_HOST', isset($dsn->port) ? "{$dsn->host}:{$dsn->port}" : $dsn->host);
 }
 


### PR DESCRIPTION
The DSN support added last week broke all of my sites running Bedrock in PHP5. I see that PHP5 support has been dropped from the project a few weeks ago, but for the sake of argument, the next line below is using syntax that is compatible.