### PR TITLE
Adjust logic to handle empty DB_PREFIX

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -61,7 +61,7 @@ Config::define('DB_PASSWORD', env('DB_PASSWORD'));
 Config::define('DB_HOST', env('DB_HOST') ?: 'localhost');
 Config::define('DB_CHARSET', 'utf8mb4');
 Config::define('DB_COLLATE', '');
-$table_prefix = (env('DB_PREFIX') || env('DB_PREFIX') === '') ? env('DB_PREFIX') : 'wp_';
+$table_prefix = empty(env('DB_PREFIX')) ? env('DB_PREFIX') : 'wp_'
 
 if (env('DATABASE_URL')) {
     $dsn = (object) parse_url(env('DATABASE_URL'));

--- a/config/application.php
+++ b/config/application.php
@@ -61,7 +61,7 @@ Config::define('DB_PASSWORD', env('DB_PASSWORD'));
 Config::define('DB_HOST', env('DB_HOST') ?: 'localhost');
 Config::define('DB_CHARSET', 'utf8mb4');
 Config::define('DB_COLLATE', '');
-$table_prefix = env('DB_PREFIX') ?: 'wp_';
+$table_prefix = (env('DB_PREFIX') || env('DB_PREFIX') === '') ? env('DB_PREFIX') : 'wp_';
 
 if (env('DATABASE_URL')) {
     $dsn = (object) parse_url(env('DATABASE_URL'));


### PR DESCRIPTION
I had a site that was not using prefixes on the database. Bedrock does not support this and evaluates `DB_PREFIX=''` as `false`.