### PR TITLE
Configure wp-cli so that `wp server` uses correct webroot

### DIFF
--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,1 +1,3 @@
 path: web/wp
+server:
+  docroot: web


### PR DESCRIPTION
This configures `wp server` to use the proper webroot by default, so that you don't need to run `wp server --docroot=web`.