### PR TITLE
If WP_HOME it's defined in config file, domain is not set in WP_CONTENT_URL

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -50,7 +50,6 @@ Config::define('WP_SITEURL', env('WP_SITEURL'));
  */
 Config::define('CONTENT_DIR', '/app');
 Config::define('WP_CONTENT_DIR', $webroot_dir . Config::get('CONTENT_DIR'));
-Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_DIR'));
 
 /**
  * DB settings
@@ -114,6 +113,11 @@ $env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
 if (file_exists($env_config)) {
     require_once $env_config;
 }
+
+/**
+ * Custom Content URL
+ */
+Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_DIR'));
 
 Config::apply();
 


### PR DESCRIPTION
When you use config files instead of .env files, when defining WP_CONTENT_URL, Config::get('WP_HOME') is empty, so WP_CONTENT_URL value is set as:
`/app` instead of `<WP_HOME value>/app`

This happens when you create `config/environments/<file>.php` and has defined `Config::define('WP_HOME', 'http://example.com');`.