### PR TITLE
Discourage environment-specific config

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -26,12 +26,6 @@ if (file_exists($root_dir . '/.env')) {
  */
 define('WP_ENV', env('WP_ENV') ?: 'production');
 
-$env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
-
-if (file_exists($env_config)) {
-    require_once $env_config;
-}
-
 /**
  * URLs
  */
@@ -73,7 +67,26 @@ define('NONCE_SALT', env('NONCE_SALT'));
  */
 define('AUTOMATIC_UPDATER_DISABLED', true);
 define('DISABLE_WP_CRON', env('DISABLE_WP_CRON') ?: false);
+// Disable the plugin and theme file editor in the admin
 define('DISALLOW_FILE_EDIT', true);
+// Disable plugin and theme updates and installation from the admin
+define('DISALLOW_FILE_MODS', true);
+
+/**
+ * Safe Debugging Settings
+ * Override these in config/{WP_ENV}.php
+ */
+ini_set('display_errors', 0);
+define('WP_DEBUG_DISPLAY', false);
+define('SCRIPT_DEBUG', false);
+
+/**
+ * Load WP_ENV specific configuration overrides
+ */
+$env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
+if (file_exists($env_config)) {
+    require_once $env_config;
+}
 
 /**
  * Bootstrap WordPress

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -1,5 +1,10 @@
 <?php
-/** Development */
+/** Configuration Overrides for Development */
+// Enable plugin and theme updates and installation from the admin
+define('DISALLOW_FILE_MODS', false);
+
 define('SAVEQUERIES', true);
-define('WP_DEBUG', true);
 define('SCRIPT_DEBUG', true);
+define('WP_DEBUG', true);
+define('WP_DEBUG_DISPLAY', true);
+ini_set('display_errors', 1);

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -1,7 +1,2 @@
 <?php
-/** Production */
-ini_set('display_errors', 0);
-define('WP_DEBUG_DISPLAY', false);
-define('SCRIPT_DEBUG', false);
-/** Disable all file modifications including updates and update notifications */
-define('DISALLOW_FILE_MODS', true);
+/** Configuration Overrides for Production */

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -1,7 +1,2 @@
 <?php
-/** Staging */
-ini_set('display_errors', 0);
-define('WP_DEBUG_DISPLAY', false);
-define('SCRIPT_DEBUG', false);
-/** Disable all file modifications including updates and update notifications */
-define('DISALLOW_FILE_MODS', true);
+/** Configuration Overrides for Staging */


### PR DESCRIPTION
Position environment-specific configuration as 'overrides'. Ideally you
want everything to behave as closely as possible to production and only
deviate when it is absolutely necessary such as a QA or development
environment.

- Increases readability
- Increase parity between environments
- Fail safe instead of fail open with regard to defaults in unknown
environments
- DRY