### PR TITLE
Disable WordPress' built-in fatal error handler on development

### DIFF
--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -8,6 +8,7 @@ use Roots\WPConfig\Config;
 Config::define('SAVEQUERIES', true);
 Config::define('WP_DEBUG', true);
 Config::define('WP_DEBUG_DISPLAY', true);
+Config::define('WP_DISABLE_FATAL_ERROR_HANDLER', true);
 Config::define('SCRIPT_DEBUG', true);
 
 ini_set('display_errors', 1);


### PR DESCRIPTION
This was brought up in Slack. Not only is the error handler somewhat redundant, it is also producing some not so wanted behavior such as sending out emails to the admin email when an error occurs which could be rather intrusive if you have a mail server present on the development environment as it could potentially push an email to a client, etc.