### PR TITLE
Editorconfig updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,3 @@
-# editorconfig.org
-
 root = true
 
 [*]
@@ -12,3 +10,6 @@ insert_final_newline = true
 
 [*.php]
 indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
- Remove unnecessary comment
- Add `trim_trailing_whitespace = false` out of good measure as to allow line breaks in markdown files.