### PR TITLE
Add spaces after ! unary operators

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -25,10 +25,12 @@ Env::init();
  * Use Dotenv to set required environment variables and load .env file in root
  */
 $dotenv = Dotenv\Dotenv::create($root_dir);
+
 if (file_exists($root_dir . '/.env')) {
     $dotenv->load();
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);
-    if (!env('DATABASE_URL')) {
+
+    if (! env('DATABASE_URL')) {
         $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD']);
     }
 }
@@ -120,6 +122,6 @@ Config::apply();
 /**
  * Bootstrap WordPress
  */
-if (!defined('ABSPATH')) {
+if (! defined('ABSPATH')) {
     define('ABSPATH', $webroot_dir . '/wp/');
 }

--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -11,7 +11,7 @@
 
 namespace Roots\Bedrock;
 
-if (!is_blog_installed()) {
+if (! is_blog_installed()) {
     return;
 }
 
@@ -92,7 +92,7 @@ class Autoloader
         $screen = get_current_screen();
         $current = is_multisite() ? 'plugins-network' : 'plugins';
 
-        if ($screen->base !== $current || $type !== 'mustuse' || !current_user_can('activate_plugins')) {
+        if ($screen->base !== $current || $type !== 'mustuse' || ! current_user_can('activate_plugins')) {
             return $show;
         }
 
@@ -135,7 +135,7 @@ class Autoloader
         $this->autoPlugins = get_plugins($this->relativePath);
         $this->muPlugins   = get_mu_plugins();
         $plugins           = array_diff_key($this->autoPlugins, $this->muPlugins);
-        $rebuild           = !is_array($this->cache['plugins']);
+        $rebuild           = ! is_array($this->cache['plugins']);
         $this->activated   = $rebuild ? $plugins : array_diff_key($plugins, $this->cache['plugins']);
         $this->cache       = ['plugins' => $plugins, 'count' => $this->countPlugins()];
 
@@ -149,7 +149,7 @@ class Autoloader
      */
     private function pluginHooks()
     {
-        if (!is_array($this->activated)) {
+        if (! is_array($this->activated)) {
             return;
         }
 
@@ -164,7 +164,7 @@ class Autoloader
     private function validatePlugins()
     {
         foreach ($this->cache['plugins'] as $plugin_file => $plugin_info) {
-            if (!file_exists(WPMU_PLUGIN_DIR . '/' . $plugin_file)) {
+            if (! file_exists(WPMU_PLUGIN_DIR . '/' . $plugin_file)) {
                 $this->updateCache();
                 break;
             }
@@ -187,7 +187,7 @@ class Autoloader
 
         $count = count(glob(WPMU_PLUGIN_DIR . '/*/', GLOB_ONLYDIR | GLOB_NOSORT));
 
-        if (!isset($this->cache['count']) || $count !== $this->cache['count']) {
+        if (! isset($this->cache['count']) || $count !== $this->cache['count']) {
             $this->count = $count;
             $this->updateCache();
         }

--- a/web/app/mu-plugins/disallow-indexing.php
+++ b/web/app/mu-plugins/disallow-indexing.php
@@ -9,6 +9,6 @@ Author URI:   https://roots.io/
 License:      MIT License
 */
 
-if (defined('WP_ENV') && WP_ENV !== 'production' && !is_admin()) {
+if (defined('WP_ENV') && WP_ENV !== 'production' && ! is_admin()) {
     add_action('pre_option_blog_public', '__return_zero');
 }

--- a/web/app/mu-plugins/register-theme-directory.php
+++ b/web/app/mu-plugins/register-theme-directory.php
@@ -9,6 +9,6 @@ Author URI:   https://roots.io/
 License:      MIT License
 */
 
-if (!defined('WP_DEFAULT_THEME')) {
+if (! defined('WP_DEFAULT_THEME')) {
     register_theme_directory(ABSPATH . 'wp-content/themes');
 }


### PR DESCRIPTION
- Add spaces after `!` unary operators in compliance with [PSR-1](https://www.php-fig.org/psr/psr-1/) (as well as the current code style of Acorn, Sage 10, etc. in relation to Laravel)