### PR TITLE
Remove phpcs.xml from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 /.circleci export-ignore
 /.editorconfig export-ignore
 /.gitattributes export-ignore
-/phpcs.xml export-ignore


### PR DESCRIPTION
With #455 revealing that `phpcs.xml` is actually used by people leading to #461 – it seems like it would be ideal if `phpcs.xml` is pulled down when creating a project.