### PR TITLE
Document and suggest quoting .env var values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,18 @@
-DB_NAME=database_name
-DB_USER=database_user
-DB_PASSWORD=database_password
+DB_NAME='database_name'
+DB_USER='database_user'
+DB_PASSWORD='database_password'
 
 # Optionally, you can use a data source name (DSN)
 # When using a DSN, you can remove the DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST variables
-# DATABASE_URL=mysql://database_user:database_password@database_host:database_port/database_name
+# DATABASE_URL='mysql://database_user:database_password@database_host:database_port/database_name'
 
 # Optional variables
-# DB_HOST=localhost
-# DB_PREFIX=wp_
+# DB_HOST='localhost'
+# DB_PREFIX='wp_'
 
-WP_ENV=development
-WP_HOME=http://example.com
-WP_SITEURL=${WP_HOME}/wp
+WP_ENV='development'
+WP_HOME='http://example.com'
+WP_SITEURL='${WP_HOME}/wp'
 
 # Generate your keys here: https://roots.io/salts.html
 AUTH_KEY='generateme'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
     ```sh
     $ composer create-project roots/bedrock
     ```
-2. Update environment variables in the `.env` file:
+2. Update environment variables in the `.env` file. Wrap values that may contain non-alphanumeric characters with quotes, or they may be incorrectly parsed.
   * Database variables
     * `DB_NAME` - Database name
     * `DB_USER` - Database user


### PR DESCRIPTION
Issue #469 points out that characters following a `#` in the value of an unquoted string in an `.env` file will be parsed as a comment, which is demonstrably undesirable. https://github.com/vlucas/phpdotenv/issues/354 confirms that this is the intended behavior of the library Bedrock uses and that quoting the string in question solves the problem, but the Bedrock README doesn't make any mention of this and the example `.env` uses quotes only on the WordPress keys, implying that other values may not need quoting. 

For this PR I've wrapped all values in the example `.env` with single quotes. I've only used single quotes to match what the Roots key generator uses and the quotes already present in `.env.example`. So far as I can tell, dotenv considers `'` and `"` the same for the purposes of quoting values.