### PR TITLE
Symlink .gitignore -> .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
Although this repo doesn't have a Docker recipe (I could contribute mine but I wonder if that's too opinionated to be here), I believe other docker users around have their own boilerplate repos where they point their build contexts into the `site` directory but end up needing to create this file manually.

It's a small change but I believe it's going to save people's time, especially because .dockerignore doesn't resolve recursively and narrowing the build context is a good practice anyway.

[Do not ignore .dockerignore](https://codefresh.io/docker-tutorial/not-ignore-dockerignore-2/)