### PR TITLE
fix(debug-log): WP_DEBUG_LOG should be `true` by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,14 +6,16 @@ DB_PASSWORD='database_password'
 # When using a DSN, you can remove the DB_NAME, DB_USER, DB_PASSWORD, and DB_HOST variables
 # DATABASE_URL='mysql://database_user:database_password@database_host:database_port/database_name'
 
-# Optional variables
+# Optional database variables
 # DB_HOST='localhost'
 # DB_PREFIX='wp_'
 
 WP_ENV='development'
 WP_HOME='http://example.com'
 WP_SITEURL="${WP_HOME}/wp"
-WP_DEBUG_LOG=/path/to/debug.log
+
+# Specify optional debug.log path
+# WP_DEBUG_LOG='/path/to/debug.log'
 
 # Generate your keys here: https://roots.io/salts.html
 AUTH_KEY='generateme'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Default to `WP_DEBUG_LOG=true` in development ([#505](https://github.com/roots/bedrock/pull/505))
 * Support `.env.local` config override ([#594](https://github.com/roots/bedrock/pull/594))
 * Use Bedrock disallow indexing package ([#521](https://github.com/roots/bedrock/pull/521))
 

--- a/config/application.php
+++ b/config/application.php
@@ -105,7 +105,7 @@ Config::define('WP_POST_REVISIONS', env('WP_POST_REVISIONS') ?: true);
  * Debugging Settings
  */
 Config::define('WP_DEBUG_DISPLAY', false);
-Config::define('WP_DEBUG_LOG', env('WP_DEBUG_LOG') ?? false);
+Config::define('WP_DEBUG_LOG', false);
 Config::define('SCRIPT_DEBUG', false);
 ini_set('display_errors', '0');
 

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -4,10 +4,12 @@
  */
 
 use Roots\WPConfig\Config;
+use function Env\env;
 
 Config::define('SAVEQUERIES', true);
 Config::define('WP_DEBUG', true);
 Config::define('WP_DEBUG_DISPLAY', true);
+Config::define('WP_DEBUG_LOG', env('WP_DEBUG_LOG') ?? true);
 Config::define('WP_DISABLE_FATAL_ERROR_HANDLER', true);
 Config::define('SCRIPT_DEBUG', true);
 Config::define('DISALLOW_INDEXING', true);


### PR DESCRIPTION
Setting WP_DEBUG_LOG to `true` will cause WP to automatically log debug output to <WP_CONTENT>/debug.log (so app/debug.log). This is a sensible default.

See: https://wordpress.org/support/article/debugging-in-wordpress/#wp_debug_log