### PR TITLE
fix: env function collide

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -25,11 +25,6 @@ $root_dir = dirname(__DIR__);
 $webroot_dir = $root_dir . '/web';
 
 /**
- * Expose global env() function from oscarotero/env
- */
-Env::init();
-
-/**
  * Use Dotenv to set required environment variables and load .env file in root
  */
 $dotenv = Dotenv\Dotenv::createImmutable($root_dir);

--- a/config/application.php
+++ b/config/application.php
@@ -36,7 +36,7 @@ $dotenv = Dotenv\Dotenv::createImmutable($root_dir);
 if (file_exists($root_dir . '/.env')) {
     $dotenv->load();
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);
-    if (!env('DATABASE_URL')) {
+    if (!Env::get('DATABASE_URL')) {
         $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD']);
     }
 }
@@ -45,13 +45,13 @@ if (file_exists($root_dir . '/.env')) {
  * Set up our global environment constant and load its config first
  * Default: production
  */
-define('WP_ENV', env('WP_ENV') ?: 'production');
+define('WP_ENV', Env::get('WP_ENV') ?: 'production');
 
 /**
  * URLs
  */
-Config::define('WP_HOME', env('WP_HOME'));
-Config::define('WP_SITEURL', env('WP_SITEURL'));
+Config::define('WP_HOME', Env::get('WP_HOME'));
+Config::define('WP_SITEURL', Env::get('WP_SITEURL'));
 
 /**
  * Custom Content Directory
@@ -63,16 +63,16 @@ Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_D
 /**
  * DB settings
  */
-Config::define('DB_NAME', env('DB_NAME'));
-Config::define('DB_USER', env('DB_USER'));
-Config::define('DB_PASSWORD', env('DB_PASSWORD'));
-Config::define('DB_HOST', env('DB_HOST') ?: 'localhost');
+Config::define('DB_NAME', Env::get('DB_NAME'));
+Config::define('DB_USER', Env::get('DB_USER'));
+Config::define('DB_PASSWORD', Env::get('DB_PASSWORD'));
+Config::define('DB_HOST', Env::get('DB_HOST') ?: 'localhost');
 Config::define('DB_CHARSET', 'utf8mb4');
 Config::define('DB_COLLATE', '');
-$table_prefix = env('DB_PREFIX') ?: 'wp_';
+$table_prefix = Env::get('DB_PREFIX') ?: 'wp_';
 
-if (env('DATABASE_URL')) {
-    $dsn = (object) parse_url(env('DATABASE_URL'));
+if (Env::get('DATABASE_URL')) {
+    $dsn = (object) parse_url(Env::get('DATABASE_URL'));
 
     Config::define('DB_NAME', substr($dsn->path, 1));
     Config::define('DB_USER', $dsn->user);
@@ -83,20 +83,20 @@ if (env('DATABASE_URL')) {
 /**
  * Authentication Unique Keys and Salts
  */
-Config::define('AUTH_KEY', env('AUTH_KEY'));
-Config::define('SECURE_AUTH_KEY', env('SECURE_AUTH_KEY'));
-Config::define('LOGGED_IN_KEY', env('LOGGED_IN_KEY'));
-Config::define('NONCE_KEY', env('NONCE_KEY'));
-Config::define('AUTH_SALT', env('AUTH_SALT'));
-Config::define('SECURE_AUTH_SALT', env('SECURE_AUTH_SALT'));
-Config::define('LOGGED_IN_SALT', env('LOGGED_IN_SALT'));
-Config::define('NONCE_SALT', env('NONCE_SALT'));
+Config::define('AUTH_KEY', Env::get('AUTH_KEY'));
+Config::define('SECURE_AUTH_KEY', Env::get('SECURE_AUTH_KEY'));
+Config::define('LOGGED_IN_KEY', Env::get('LOGGED_IN_KEY'));
+Config::define('NONCE_KEY', Env::get('NONCE_KEY'));
+Config::define('AUTH_SALT', Env::get('AUTH_SALT'));
+Config::define('SECURE_AUTH_SALT', Env::get('SECURE_AUTH_SALT'));
+Config::define('LOGGED_IN_SALT', Env::get('LOGGED_IN_SALT'));
+Config::define('NONCE_SALT', Env::get('NONCE_SALT'));
 
 /**
  * Custom Settings
  */
 Config::define('AUTOMATIC_UPDATER_DISABLED', true);
-Config::define('DISABLE_WP_CRON', env('DISABLE_WP_CRON') ?: false);
+Config::define('DISABLE_WP_CRON', Env::get('DISABLE_WP_CRON') ?: false);
 // Disable the plugin and theme file editor in the admin
 Config::define('DISALLOW_FILE_EDIT', true);
 // Disable plugin and theme updates and installation from the admin
@@ -106,7 +106,7 @@ Config::define('DISALLOW_FILE_MODS', true);
  * Debugging Settings
  */
 Config::define('WP_DEBUG_DISPLAY', false);
-Config::define('WP_DEBUG_LOG', env('WP_DEBUG_LOG') ?? false);
+Config::define('WP_DEBUG_LOG', Env::get('WP_DEBUG_LOG') ?? false);
 Config::define('SCRIPT_DEBUG', false);
 ini_set('display_errors', '0');
 


### PR DESCRIPTION
As mentionned in #515 the `env` function is colliding with the one defined in `illuminate/support`, so why not to use directly the `Env::get` function. 