### PR TITLE
CircleCI: Use offical CircleCI PHP orb and next-gen docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,52 +1,13 @@
 version: 2.1
 
 orbs:
-  bedrock:
-    executors:
-      php-latest:
-        docker:
-          - image: 'circleci/php:latest'
-      php-73:
-        docker:
-          - image: 'circleci/php:7.3-stretch'
-      php-72:
-        docker:
-          - image: 'circleci/php:7.2-stretch'
-      php-71:
-        docker:
-          - image: 'circleci/php:7.1-stretch'
-    jobs:
-      build-php:
-        parameters:
-          executor:
-            type: executor
-        executor: << parameters.executor >>
-        steps:
-          - run: php -v
-          - checkout
-          - restore_cache:
-              keys:
-                - composer-v1-{{ checksum "composer.lock" }}
-                - composer-v1-
-          - run: composer install -n --prefer-dist
-          - run: composer test
-          - save_cache:
-              key: composer-v1-{{ checksum "composer.lock" }}
-              paths:
-                - vendor
+  php: circleci/php@1
 
 workflows:
   build:
     jobs:
-      - bedrock/build-php:
-          name: build-php-latest
-          executor: bedrock/php-latest
-      - bedrock/build-php:
-          name: build-php-73
-          executor: bedrock/php-73
-      - bedrock/build-php:
-          name: build-php-72
-          executor: bedrock/php-72
-      - bedrock/build-php:
-          name: build-php-71
-          executor: bedrock/php-71
+      - php/test:
+          name: php-<< matrix.version >>
+          matrix:
+            parameters:
+              version: ["7.4", "7.3", "7.2"]


### PR DESCRIPTION
#### Changes

- use offical CircleCI [PHP orb](https://circleci.com/orbs/registry/orb/circleci/php)
- use offical CircleCI [next-gen docker images](https://circleci.com/docs/2.0/circleci-images/#next-generation-convenience-images)
- use [`matrix`](https://circleci.com/docs/2.0/configuration-reference/#matrix-requires-version-21)

#### Notes

Dropped PHP 7.1 testing because of https://github.com/CircleCI-Public/cimg-php/issues/1#issuecomment-545532033

> Is it possible to add back PHP 7.1 test with the new php orb?

Yes. Let me know if we need it.

#### Benchmark

Not much difference actually.
Downloading the docker image, which ranging from 3 to 40 second depends whether the CircleCI instance has the docker layer cached, makes up the most of the build time.

With CircleCI pushing its new docker images forward, I expect the cache hit rate to go up in the coming months.
