### PR TITLE
add MU plugin that disables two site health status tests 'conflicting' with bedrock

### DIFF
--- a/web/app/mu-plugins/disable-status-tests.php
+++ b/web/app/mu-plugins/disable-status-tests.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Plugin Name:  Disable status tests
+ * Plugin URI:   https://github.com/roots/bedrock/
+ * Description:  Disable two status tests that conflict with the way Bedrock is intended.
+ * Version:      1.0.0
+ * Author:       Roots
+ * Author URI:   https://roots.io/
+ * License:      MIT License
+ */
+
+namespace Roots\Bedrock;
+
+add_filter('site_status_tests', __NAMESPACE__ . '\\disable_status_tests');
+
+/**
+ * Disable WordPress Health Status tests
+ * 
+ * Disables tests that currently conflict with the way WordPress is intened.
+ *
+ * @param array $tests
+ * @return void
+ */
+function disable_status_tests($tests)
+{
+   unset($tests['direct']['theme_version']); // disable theme update, theme inactive and default theme checks.
+   unset($tests['async']['background_updates']); // disabled the background updates check.
+   return $tests;
+}


### PR DESCRIPTION
![fixes](https://user-images.githubusercontent.com/17764157/88784452-5a60a380-d190-11ea-84c6-8cb1342de44b.PNG)

The PR removes the two Site Health Status notifications highlighted in red in the screenshot.

- Auto updates test, mentioned by @retlehs in #522 since Bedrock discourages auto-update by design, we disable the `background_updates` check.
- Theme update check , mentioned by @yangm97 in #522 By disabling `theme_version` we disable the test that checks if there is a default theme available, the default 'default theme' is twentytwenty. Since most bedrock installs will probably come without this default theme, this triggers the advice.
As a side effect the actual theme update checks aren't done as well. So I am not sure if disabling this test is the way to go.

The code run by the `theme_version` check can be found [here](https://github.com/WordPress/WordPress/blob/ef382e6aafaf4b826e8f60fec4bb826c9612da3e/wp-admin/includes/class-wp-site-health.php#L477)

This is my first PR attempt for a Roots project. So let me know if I missed something or something can be improved.
