### PR TITLE
Adds support for WP_ENVIRONMENT_TYPE

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -36,12 +36,26 @@ if (file_exists($root_dir . '/.env')) {
         $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD']);
     }
 }
+/**
+ * Set up Environment Types
+ * Default: production, staging, development
+ */
+Config::define('WP_ENVIRONMENT_TYPES', env('WP_ENVIRONMENT_TYPES') ? explode(',', env('WP_ENVIRONMENT_TYPES')) : ['production', 'staging', 'development']);
 
 /**
- * Set up our global environment constant and load its config first
- * Default: production
+ * Set up WP_ENV and WP_ENVIRONMENT_TYPE based on which
+ * constants are set
  */
-define('WP_ENV', env('WP_ENV') ?: 'production');
+if (env('WP_ENV') || env('WP_ENVIRONMENT_TYPE')) {
+    Config::define('WP_ENV', env('WP_ENV') ?: env('WP_ENVIRONMENT_TYPE'));
+    Config::define('WP_ENVIRONMENT_TYPE', env('WP_ENVIRONMENT_TYPE') ?: env('WP_ENV'));
+    define('WP_ENV', env('WP_ENV') ?: env('WP_ENVIRONMENT_TYPE'));
+} else {
+    Config::define('WP_ENV', 'production');
+    define('WP_ENV', 'production');
+}
+
+Config::define('DB_NAME', env('DB_NAME'));
 
 /**
  * URLs

--- a/config/application.php
+++ b/config/application.php
@@ -55,8 +55,6 @@ if (env('WP_ENV') || env('WP_ENVIRONMENT_TYPE')) {
     define('WP_ENV', 'production');
 }
 
-Config::define('DB_NAME', env('DB_NAME'));
-
 /**
  * URLs
  */


### PR DESCRIPTION
Based on #538 I added the support for new constants introduced in WP 5.5:
- `WP_ENVIRONMENT_TYPES`
- `WP_ENVIRONMENT_TYPE`

if `WP_ENV` is set but no `WP_ENVIRONMENT_TYPE` than `WP_ENVIRONMENT_TYPE = WP_ENV`
if `WP_ENVIRONMENT_TYPE` is set but no `WP_EVN` than `WP_ENV = WP_ENVIRONMENT_TYPE`

if none is set than `WP_ENV` is set to "production" and `wp_get_environment_type()` will return `production`.