### PR TITLE
Bump roots/wordpress-core-installer for composer 2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -371,20 +371,21 @@
         },
         {
             "name": "roots/wordpress-core-installer",
-            "version": "1.1.0",
+            "version": "1.100.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/wordpress-core-installer.git",
-                "reference": "83744b1ba5bbdb5bb225f47e24da61a6cf6c5b80"
+                "reference": "73f8488e5178c5d54234b919f823a9095e2b1847"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roots/wordpress-core-installer/zipball/83744b1ba5bbdb5bb225f47e24da61a6cf6c5b80",
-                "reference": "83744b1ba5bbdb5bb225f47e24da61a6cf6c5b80",
+                "url": "https://api.github.com/repos/roots/wordpress-core-installer/zipball/73f8488e5178c5d54234b919f823a9095e2b1847",
+                "reference": "73f8488e5178c5d54234b919f823a9095e2b1847",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.6.0"
             },
             "conflict": {
                 "composer/installers": "<1.0.6"
@@ -393,8 +394,8 @@
                 "johnpbloch/wordpress-core-installer": "*"
             },
             "require-dev": {
-                "composer/composer": "^1.0",
-                "phpunit/phpunit": ">=4.8.35"
+                "composer/composer": "^1.0 || ^2.0",
+                "phpunit/phpunit": ">=5.7.27"
             },
             "type": "composer-plugin",
             "extra": {
@@ -423,7 +424,21 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2018-12-10T00:22:15+00:00"
+            "support": {
+                "issues": "https://github.com/roots/wordpress-core-installer/issues",
+                "source": "https://github.com/roots/wordpress-core-installer/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/roots",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/rootsdev",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-08-20T00:27:30+00:00"
         },
         {
             "name": "roots/wp-config",
@@ -1036,5 +1051,5 @@
         "php": ">=7.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
ref https://github.com/roots/wordpress-core-installer/issues/4#issuecomment-716227485

![Screen Capture_select-area_20201025183002](https://user-images.githubusercontent.com/2192970/97122001-90121b80-16f0-11eb-91c6-a4568e3a0c91.png)

## changes

### before

![Screen Capture_select-area_20201025175907](https://user-images.githubusercontent.com/2192970/97122030-bc2d9c80-16f0-11eb-9653-ebcc5707d57e.png)

![Screen Capture_select-area_20201025180023](https://user-images.githubusercontent.com/2192970/97122034-bfc12380-16f0-11eb-9a4e-1027895befe2.png)

### after

![image](https://user-images.githubusercontent.com/2192970/97122123-64436580-16f1-11eb-8187-ff3a5b2339da.png)

![Screen Capture_select-area_20201025183725](https://user-images.githubusercontent.com/2192970/97122090-28100500-16f1-11eb-8f69-53a56a484665.png)

## notes for reviewer

Should be able to `composer create roots/bedrock` under both composer 1 and 2

Created project should boot an instance of WordPress just fine.