### PR TITLE
Add WP_POST_REVISIONS as an option

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -97,6 +97,8 @@ Config::define('DISABLE_WP_CRON', env('DISABLE_WP_CRON') ?: false);
 Config::define('DISALLOW_FILE_EDIT', true);
 // Disable plugin and theme updates and installation from the admin
 Config::define('DISALLOW_FILE_MODS', true);
+// Limit the number of post revisions that Wordpress stores (true (default WP): store every revision)
+Config::define('WP_POST_REVISIONS', env('WP_POST_REVISIONS') ?: true);
 
 /**
  * Debugging Settings


### PR DESCRIPTION
We more often than not, like to limit the number of post revisions in our various environments, in order to contain the size that the database can grow to (one client's wp_posts table is currently up to 200MB, after only 3 months of UAT).

Providing the ability to define this simply, via the `.env` will make the process of defining this per environment, much more convenient.

By default, it remains as `true` so not to effect the default behaviour.