### PR TITLE
Remove Legacy WP Themes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,11 @@
   },
   "scripts": {
     "post-root-package-install": [
-      "php -r \"copy('.env.example', '.env');\""
+      "php -r \"copy('.env.example', '.env');\"",
+      "composer run remove-legacy-themes"
+    ],
+    "remove-legacy-themes": [
+      "rm -rf web/wp/wp-content/themes/twenty{ten,eleven,twelve,thirteen,fourteen,fifteen,sixteen,seventeen}"
     ],
     "test": [
       "phpcs"


### PR DESCRIPTION
Post-Install removal of themes considered unsupported by WP Core (not included in the latest [release](https://wordpress.org/releases/)).

An optimized version of  @christopherdarling's patch #555, temporarily solving roots/wordpress#3 in only one(1) line, instead of eight(8).

After all, 8 bits = 1 byte 😁