### PR TITLE
Sanitize WP_HOME

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -46,7 +46,7 @@ define('WP_ENV', env('WP_ENV') ?: 'production');
 /**
  * URLs
  */
-Config::define('WP_HOME', env('WP_HOME'));
+Config::define('WP_HOME', rtrim(trim(env('WP_HOME')), '/'));
 Config::define('WP_SITEURL', env('WP_SITEURL'));
 
 /**


### PR DESCRIPTION
Ensure that WP_HOME doesn't have unwanted whitespaces (before and after). And ensure there is no trailing slashes.

Had a problem on a website that came from here (leading whitespaces), took me 1 hour to find out where was the problem.