### PR TITLE
Support .env.local config override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Support `.env.local` config override ([#594](https://github.com/roots/bedrock/pull/594))
 * Use Bedrock disallow indexing package ([#521](https://github.com/roots/bedrock/pull/521))
 
 ### 1.15.4: 2021-05-19

--- a/config/application.php
+++ b/config/application.php
@@ -27,8 +27,9 @@ $webroot_dir = $root_dir . '/web';
 
 /**
  * Use Dotenv to set required environment variables and load .env file in root
+ * .env.local will override .env if it exists
  */
-$dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir);
+$dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, ['.env', '.env.local'], false);
 if (file_exists($root_dir . '/.env')) {
     $dotenv->load();
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);


### PR DESCRIPTION
Suggested by @TangRufus in https://github.com/roots/bedrock/pull/586#issuecomment-816428722

If `.env.local` exists, any values will override and take precedence over those in `.env`. This is meant for local development only. Note: `.env.local` is already gitignored 

There's been some other related proposals in https://github.com/roots/bedrock/pull/587 and https://github.com/roots/bedrock/pull/586 but this one is simpler since it's additive only. We're just supporting a common workflow without breaking anything.