### PR TITLE
Remove post install .env copy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,9 +65,6 @@
     "wordpress-install-dir": "web/wp"
   },
   "scripts": {
-    "post-root-package-install": [
-      "php -r \"copy('.env.example', '.env');\""
-    ],
     "test": [
       "phpcs"
     ]


### PR DESCRIPTION
`.env.example` is just an example and doesn't contain useful defaults. Copying this file can be confusing since it needs to be edited regardless. By not copying this file, we'll surface errors of missing config values sooner since they'll be no default values.

This is an alternative to https://github.com/roots/bedrock/pull/587 and https://github.com/roots/bedrock/pull/586

Docs PR: https://github.com/roots/docs/pull/476