### PR TITLE
Don't leak env values into `$_SERVER`

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -39,8 +39,13 @@ if (file_exists($root_dir . '/.env')) {
         ? ['.env', '.env.local']
         : ['.env'];
 
-    $dotenv = Dotenv\Dotenv::createImmutable($root_dir, $env_files, false);
+    $repository = Dotenv\Repository\RepositoryBuilder::createWithNoAdapters()
+        ->addAdapter(Dotenv\Repository\Adapter\EnvConstAdapter::class)
+        ->addAdapter(Dotenv\Repository\Adapter\PutenvAdapter::class)
+        ->immutable()
+        ->make();
 
+    $dotenv = Dotenv\Dotenv::create($repository, $root_dir, $env_files, false);
     $dotenv->load();
 
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);


### PR DESCRIPTION
Updates to using a custom repository for `Dotenv` instead of the default which includes `ServerConstAdapter`.

The new custom repository *only* includes `EnvConstAdapter`.

The `$_SERVER` superglobal often gets dumped into logs or into monitoring services so it's better for security to avoid populating it with secrets contained in `.env`.

*Note*: this *could* be a breaking change for some users, but we at least need to ensure it's not breaking in the normal case.

Close #474