### PR TITLE
Fixes #601 - Load .env.local only if the file exists

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -29,8 +29,12 @@ $webroot_dir = $root_dir . '/web';
  * Use Dotenv to set required environment variables and load .env file in root
  * .env.local will override .env if it exists
  */
-$dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, ['.env', '.env.local'], false);
+$dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, ['.env'], false);
 if (file_exists($root_dir . '/.env')) {
+    if(file_exists($root_dir . '/.env.local')) {
+        $dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, ['.env.local'], false);
+    }
+
     $dotenv->load();
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);
     if (!env('DATABASE_URL')) {


### PR DESCRIPTION
If the file `.env.local` doesn't exists, getting a warning
`Warning: file_get_contents(/var/www/.env.local): failed to open stream: No such file or directory`

Added a check to load the `.env.local` only if the file exists