### PR TITLE
Fixes #601 - .env.local failed to open stream php warning

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -29,7 +29,11 @@ $webroot_dir = $root_dir . '/web';
  * Use Dotenv to set required environment variables and load .env file in root
  * .env.local will override .env if it exists
  */
-$dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, ['.env', '.env.local'], false);
+$env_files = file_exists($root_dir . '/.env.local')
+    ? ['.env', '.env.local']
+    : ['.env'];
+
+$dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, $env_files, false);
 if (file_exists($root_dir . '/.env')) {
     $dotenv->load();
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);


### PR DESCRIPTION
For reference: [b2781b8#commitcomment-54196503](https://github.com/roots/bedrock/commit/b2781b890e5f988f847e716e6abbc48e34c3cc5c#commitcomment-54196503)

I also removed this `if`
https://github.com/roots/bedrock/blob/master/config/application.php#L33

If .env file is not present a `\Dotenv\Exception\InvalidPathException` will be raised.

Fixes #601 