### PR TITLE
Check Composer lock file is up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
         path: /tmp/composer-cache
         key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
 
+    - name: Check Composer lock file is up to date
+      uses: php-actions/composer@v5
+      with:
+        command: validate
+        args: '--no-check-all'
+    
     - name: Install Composer dependencies
       uses: php-actions/composer@v5
 


### PR DESCRIPTION
Ensure `composer.lock` is always in sync with `composer.json`. 

A recent commit from @adamtomat [fixed an issue](https://github.com/roots/bedrock/issues/610) where the lock file was out of sync with the json. This PR adds a CI check to ensure that they are always kept in sync.