### PR TITLE
Bump requirements to PHP 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ['7.3', '7.4', '8.0']
+        php_version: ['7.4', '8.0', '8.1']
 
     steps:
     - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
       with:
         command: validate
         args: '--no-check-all'
-    
+
     - name: Install Composer dependencies
       uses: php-actions/composer@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,24 +12,26 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Cache Composer dependencies
-      uses: actions/cache@v2
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
       with:
-        path: /tmp/composer-cache
-        key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+        php_version: ${{ matrix.php_version }}
+
+    - name: Cache Composer dependencies
+      id: composer-cache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    - uses: actions/cache@v2
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
 
     - name: Check Composer lock file is up to date
-      uses: php-actions/composer@v5
-      with:
-        command: validate
-        args: '--no-check-all'
+      run: composer validate --no-check-all
 
     - name: Install Composer dependencies
-      uses: php-actions/composer@v5
+      run: composer install --no-progress --prefer-dist --optimize-autoloader
 
     - name: Run tests
-      uses: php-actions/composer@v5
-      with:
-        command: test
-        php_version: ${{ matrix.php_version }}
-        version: 2
+      run: composer test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Bump requirements to PHP 7.4 ([#619](https://github.com/roots/bedrock/pull/619))
+
 ### 1.17.1: 2021-11-16
 * Bump roots/wordpress from 5.8.1 to 5.8.2 ([#615](https://github.com/roots/bedrock/pull/615))
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
 
 ## Requirements
 
-- PHP >= 7.1
+- PHP >= 7.4
 - Composer - [Install](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.4",
     "composer/installers": "^1.12",
     "vlucas/phpdotenv": "^5.3",
     "oscarotero/env": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63f6a42862b355b520d9725b756e6a01",
+    "content-hash": "8d9556064ac0c5b5e9f309fbd02ed260",
     "packages": [
         {
             "name": "composer/installers",
@@ -1465,8 +1465,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1"
+        "php": ">=7.4"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
PHP 7.3 EOL is 2021-12-06

https://www.php.net/supported-versions.php