### PR TITLE
chore(deps): allow required composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,11 @@
   },
   "config": {
     "optimize-autoloader": true,
-    "preferred-install": "dist"
+    "preferred-install": "dist",
+    "allow-plugins": {
+      "composer/installers": true,
+      "roots/wordpress-core-installer": true
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
We require two composer plugins. As of Composer v2.2.0, the default behavior is that [plugins must be explicitly allowed](https://getcomposer.org/doc/06-config.md#allow-plugins).

![image](https://user-images.githubusercontent.com/2104321/147351667-1c35d619-d024-4d6f-bc7c-44484f02f11c.png)
