### PR TITLE
chore(deps): Bump roots/wordpress to 5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.19.0: 2022-01-25
+* Bump roots/wordpress to 5.9 ([#626](https://github.com/roots/bedrock/pull/626))
+* Bump squizlabs/php_codesniffer from 3.6.1 to 3.6.2 ([#623](https://github.com/roots/bedrock/pull/623))
+* Bump vlucas/phpdotenv from 5.3.1 to 5.4.1 ([#622](https://github.com/roots/bedrock/pull/622))
+* Bump composer/installers from 1.12.0 to 2.0.1 ([#621](https://github.com/roots/bedrock/pull/621))
+
 ### 1.18.1: 2022-01-07
 * Bump roots/wordpress from 5.8.2 to 5.8.3 ([#625](https://github.com/roots/bedrock/pull/625))
 * chore(deps): allow required composer plugins ([#624](https://github.com/roots/bedrock/pull/624))

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "oscarotero/env": "^2.1",
     "roots/bedrock-autoloader": "^1.0",
     "roots/bedrock-disallow-indexing": "^2.0",
-    "roots/wordpress": "5.8.3",
+    "roots/wordpress": "5.9",
     "roots/wp-config": "1.0.0",
     "roots/wp-password-bcrypt": "1.1.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fb56c6333648fa5cd746ca93ec4a6e5",
+    "content-hash": "d5a717838da76193d74ce33298c5f5a3",
     "packages": [
         {
             "name": "composer/installers",
@@ -458,22 +458,22 @@
         },
         {
             "name": "roots/wordpress",
-            "version": "5.8.3",
+            "version": "5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "5.8.3"
+                "reference": "5.9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/refs/tags/5.8.3"
+                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/refs/tags/5.9"
             },
             "require": {
                 "php": ">=5.3.2",
                 "roots/wordpress-core-installer": ">=1.0.0"
             },
             "provide": {
-                "wordpress/core-implementation": "5.8.3"
+                "wordpress/core-implementation": "5.9"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -512,7 +512,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-01-06T19:19:24+00:00"
+            "time": "2022-01-25T19:50:55+00:00"
         },
         {
             "name": "roots/wordpress-core-installer",
@@ -1514,5 +1514,5 @@
         "php": ">=7.4"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
https://wordpress.org/news/2022/01/josephine/