### PR TITLE
Infer `WP_ENVIRONMENT_TYPE` based on `WP_ENV`

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -48,6 +48,18 @@ if (file_exists($root_dir . '/.env')) {
  */
 define('WP_ENV', env('WP_ENV') ?: 'production');
 
+/*
+ * Infer WP_ENVIRONMENT_TYPE based on WP_ENV
+ */
+
+if (preg_match('/^(dev|review|trunk)/i', WP_ENV)) {
+    Config::define('WP_ENVIRONMENT_TYPE', env('WP_ENVIRONMENT_TYPE') ?: 'development');
+} elseif (preg_match('/^(st(a|)g|mod(e|)l|pre|demo)/i', WP_ENV)) {
+    Config::define('WP_ENVIRONMENT_TYPE', env('WP_ENVIRONMENT_TYPE') ?: 'staging');
+} else {
+    Config::define('WP_ENVIRONMENT_TYPE', env('WP_ENVIRONMENT_TYPE') ?: 'production');
+}
+
 /**
  * URLs
  */


### PR DESCRIPTION
Currently, there is a mismatch between `WP_ENV` and `WP_ENVIRONMENT_TYPE` as described in #538. As opposed to PR #543, this does not try to keep `WP_ENV` and `WP_ENVIRONMENT_TYPE` in sync but rather infer the values of the latter from the former, as suggested in https://github.com/roots/bedrock/pull/543#issuecomment-877742762.

This way for example `dev`, `trunk`, `dev-joe` all map to `WP_ENVIRONMENT_TYPE=develpoment` and `staging`, `stage-us` and `stage-eu` to `WP_ENVIRONMENT_TYPE=staging`.

In my opinion, this is more backward-compatible than setting `WP_ENV` based on defined `WP_ENVIRONMENT_TYPE` because some people can unexpectedly get their configuration switched from staging to production for example when they set `WP_ENVIRONMENT_TYPE=production`.