### PR TITLE
doc: instructions for installing "source" packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
    ```sh
    $ composer create-project roots/bedrock
    ```
+   By default, this installs the `dist` version of all dependent packages.  To install the `source` versions instead, update `composer.json` as follows:
+   ```json
+    "preferred-install": {
+      "roots/wordpress-no-content": "dist",
+      "*": "source"
+    },
+   ```
 2. Update environment variables in the `.env` file. Wrap values that may contain non-alphanumeric characters with quotes, or they may be incorrectly parsed.
 
 - Database variables


### PR DESCRIPTION
As of WordPress 6.0, the behavior changed so add a note about it per https://github.com/roots/bedrock/issues/640.