### PR TITLE
Fix GitHub Actions CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ['7.4', '8.0', '8.1']
+        php-version: ['7.4', '8.0', '8.1']
 
     steps:
     - uses: actions/checkout@v2
@@ -15,7 +15,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php_version: ${{ matrix.php_version }}
+        php-version: ${{ matrix.php-version }}
 
     - name: Cache Composer dependencies
       id: composer-cache


### PR DESCRIPTION
Fixed typo in input for [shivammathur/setup-php](https://github.com/shivammathur/setup-php), must be [`php-version`](https://github.com/shivammathur/setup-php/tree/2.21.2#php-version-required) instead of `php_version`.

This typo prevented the action from detecting the matrix job's PHP version, installing the latest version of PHP instead.

Renamed matrix job configuration from `php_version` to `php-version` for consistency with action.

[![Screen capture of Setup PHP step of Build 7.4 of Run 8116757560 warning of unexpected input 'php_version' and installation of PHP 8.1.19 instead of PHP 7.4](https://user-images.githubusercontent.com/29353/189196853-b485ce4b-3aad-46d0-b4fc-dbc062746e62.jpg)](https://github.com/roots/bedrock/runs/8116757560?check_suite_focus=true#step:3:1)