### PR TITLE
fix: can disable revisions by setting false or 0

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -103,7 +103,7 @@ Config::define('DISALLOW_FILE_EDIT', true);
 // Disable plugin and theme updates and installation from the admin
 Config::define('DISALLOW_FILE_MODS', true);
 // Limit the number of post revisions that Wordpress stores (true (default WP): store every revision)
-Config::define('WP_POST_REVISIONS', env('WP_POST_REVISIONS') ?: true);
+Config::define('WP_POST_REVISIONS', env('WP_POST_REVISIONS') ?? true);
 
 /**
  * Debugging Settings


### PR DESCRIPTION
Hi, noticed that the default setup for application.php does not allow to turn off revisions through the value of `WP_POST_REVISIONS`. Setting either false or 0 results on enabling the feature completely, which is pretty confusing.