### PR TITLE
Added support for SSL database connections

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -64,6 +64,10 @@ Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_D
 /**
  * DB settings
  */
+if (env('DB_SSL')) {
+    Config::define('MYSQL_CLIENT_FLAGS', MYSQLI_CLIENT_SSL);
+}
+
 Config::define('DB_NAME', env('DB_NAME'));
 Config::define('DB_USER', env('DB_USER'));
 Config::define('DB_PASSWORD', env('DB_PASSWORD'));


### PR DESCRIPTION
Passing the `DB_SSL` environment variable can trigger the use of SSL client connections to MySQL. This is especially useful for remote/managed databases where SSL certificates are required.

Pulled from https://discourse.roots.io/t/roots-with-digital-ocean-managed-databases/16582.