### PR TITLE
🔧 Bump requirements to PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
 
 ## Requirements
 
-- PHP >= 7.4
+- PHP >= 8.0
 - Composer - [Install](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4",
+    "php": ">=8.0",
     "composer/installers": "^2.2",
     "vlucas/phpdotenv": "^5.5",
     "oscarotero/env": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8199b06f9812c8705de223a6ab5def06",
+    "content-hash": "1ce5a2883dc45ffe844d2a2f0bcff58c",
     "packages": [
         {
             "name": "composer/installers",
@@ -1598,7 +1598,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"


### PR DESCRIPTION
https://www.php.net/supported-versions.php
https://endoflife.date/php

I'd prefer to bump this to PHP 8.1, considering active support for PHP 8.0 ended on 2022-11-26, but WordPress & WP-CLI _still_ don't fully support it at this time

Ref **https://roots.io/wordpress-php-8-1-support-not-found/**
Ref https://core.trac.wordpress.org/ticket/54504 (coming in WordPress 6.2)
Ref https://github.com/wp-cli/wp-cli/issues/5623