### PR TITLE
Don't instantiate Dotenv if .env file not exists

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -29,13 +29,15 @@ $webroot_dir = $root_dir . '/web';
  * Use Dotenv to set required environment variables and load .env file in root
  * .env.local will override .env if it exists
  */
-$env_files = file_exists($root_dir . '/.env.local')
-    ? ['.env', '.env.local']
-    : ['.env'];
-
-$dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, $env_files, false);
 if (file_exists($root_dir . '/.env')) {
+    $env_files = file_exists($root_dir . '/.env.local')
+        ? ['.env', '.env.local']
+        : ['.env'];
+
+    $dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, $env_files, false);
+
     $dotenv->load();
+
     $dotenv->required(['WP_HOME', 'WP_SITEURL']);
     if (!env('DATABASE_URL')) {
         $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD']);


### PR DESCRIPTION
In `production` environment `.env` files are never used, so we don't need to create `Dotenv` instance if `.env` file not exists.