### PR TITLE
chore: creates .env only if not exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
   },
   "scripts": {
     "post-root-package-install": [
-      "php -r \"copy('.env.example', '.env');\""
+      "php -r \"file_exists('.env') || copy('.env.example', '.env');\""
     ],
     "test": [
       "phpcs"


### PR DESCRIPTION
Following up to #595 

Given post install creates an .env based on .env.example 
it is useful to happen only if .env doesn't exist 
similar to what other open source projects do.

