### PR TITLE
Add integration test workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,25 @@
+name: Integration
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: roots/bedrock-docker
+        ref: main
+        path: bedrock-docker
+    - uses: actions/checkout@v2
+      with:
+        path: bedrock-docker/bedrock
+    - name: Build and run
+      run: docker compose up --build -d
+      working-directory: bedrock-docker
+    - name: Wait for install
+      run: sleep 30
+      working-directory: bedrock-docker
+    - name: Verify install
+      run: curl -s http://127.0.0.1 | grep "<title>bedrock"
+      working-directory: bedrock-docker


### PR DESCRIPTION
Note: `roots/bedrock-docker` is not meant for production. It's mainly to help CI workflows like this.