### PR TITLE
ADD: `local` environment in application.php

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -53,7 +53,7 @@ define('WP_ENV', env('WP_ENV') ?: 'production');
 /**
  * Infer WP_ENVIRONMENT_TYPE based on WP_ENV
  */
-if (!env('WP_ENVIRONMENT_TYPE') && in_array(WP_ENV, ['production', 'staging', 'development'])) {
+if (!env('WP_ENVIRONMENT_TYPE') && in_array(WP_ENV, ['production', 'staging', 'development', 'local'])) {
     Config::define('WP_ENVIRONMENT_TYPE', WP_ENV);
 }
 


### PR DESCRIPTION
To fix this issue : https://github.com/roots/bedrock/issues/679

According to [official documentation](https://developer.wordpress.org/reference/functions/wp_get_environment_type/), add 'local' in the array in application.php.