### PR TITLE
fix: The `set-output` command is deprecated and will be disabled soon.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Cache Composer dependencies
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v4
       with:


### PR DESCRIPTION
This PR Fixes warnings in CI action.

<img width="1164" alt="Screenshot 2024-02-02 at 7 04 08 PM" src="https://github.com/roots/bedrock/assets/6929121/14addcc4-a165-48dc-bde7-d74c1aa24835">

Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/