### PR TITLE
💥 use `Dotenv::createImmutable()`

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -11,6 +11,9 @@
 use Roots\WPConfig\Config;
 use function Env\env;
 
+// USE_ENV_ARRAY + CONVERT_* + STRIP_QUOTES
+Env\Env::$options = 31;
+
 /**
  * Directory containing all of the site's files
  *
@@ -34,7 +37,7 @@ if (file_exists($root_dir . '/.env')) {
         ? ['.env', '.env.local']
         : ['.env'];
 
-    $dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, $env_files, false);
+    $dotenv = Dotenv\Dotenv::createImmutable($root_dir, $env_files, false);
 
     $dotenv->load();
 


### PR DESCRIPTION
This has been brought up a few times internally and in [the comments in this repo](https://github.com/roots/bedrock/pull/563#issuecomment-953925928).

Here's an example scenario in a multithreaded environment:

> Putenv and Getenv are not thread-safe. This is probably the cause of your issue.
> 
> What happens is the following:
> 1st request: variables are not there -> load
> 2nd request: variables are there -> do not load
> 1st request: ends, cleans up variables
> 2nd request: use variable -> does not exist anymore, cleaned up by 1st request

h/t https://github.com/vlucas/phpdotenv/issues/248#issuecomment-450903446

The rest of the PHP community has largely moved away from `putenv()` and `getenv()` due to this limitation, and it's the reason why vlucas/phpdotenv moved away from it as a default and [advises against it in their readme](https://github.com/vlucas/phpdotenv#putenv-and-getenv).

> Using `getenv()` and `putenv()` is strongly discouraged due to the fact that these functions are not thread safe