### PR TITLE
🔧 Disable script concatenation by default

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -124,6 +124,9 @@ Config::define('DISALLOW_FILE_MODS', true);
 // Limit the number of post revisions
 Config::define('WP_POST_REVISIONS', env('WP_POST_REVISIONS') ?? true);
 
+// Disable script concatenation
+Config::define('CONCATENATE_SCRIPTS', false);
+
 /**
  * Debugging Settings
  */


### PR DESCRIPTION
This PR sets `CONCATENATE_SCRIPTS` to false by default which prevents WordPress from concatenating scripts

Ref https://discourse.roots.io/t/upstream-timed-out-for-load-styles-php/26973