### PR TITLE
Revert "Require project autoloader in wp-cli.yml"

### DIFF
--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,5 +1,3 @@
 path: web/wp
-require:
-  - vendor/autoload.php
 server:
   docroot: web


### PR DESCRIPTION
Reverts roots/bedrock#636

See https://github.com/roots/bedrock/commit/566407b9df7a8a7ab7c67f410ac8a931fa676410#commitcomment-141640789