### PR TITLE
Avoid redefining `DISALLOW_FILE_EDIT`

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -116,7 +116,9 @@ Config::define('AUTOMATIC_UPDATER_DISABLED', true);
 Config::define('DISABLE_WP_CRON', env('DISABLE_WP_CRON') ?: false);
 
 // Disable the plugin and theme file editor in the admin
-Config::define('DISALLOW_FILE_EDIT', true);
+if (!defined('DISALLOW_FILE_EDIT')) {
+    Config::define('DISALLOW_FILE_EDIT', true);
+}
 
 // Disable plugin and theme updates and installation from the admin
 Config::define('DISALLOW_FILE_MODS', true);


### PR DESCRIPTION
Some security plugins will automatically edit `wp-config.php` and then throw an error:

```
Fatal error: Uncaught Roots\WPConfig\Exceptions\ConstantAlreadyDefinedException:
Aborted trying to redefine constant 'DISALLOW_FILE_EDIT'.
`define('DISALLOW_FILE_EDIT', ...)` has already been occurred elsewhere.
```

I know this happens with at least two plugins:

- Solid Security Pro (occurs automatically upon activation)
- Sucuri Security (occurs when option is activated in settings)

Of course, adding these constants to `wp-config.php` in Bedrock isn't ideal, but this check at least keeps the fatal error from triggering when working with these plugins. 

I'm not sold this is something that Bedrock needs to address... It's just something I've encountered a few times in the wild. I could be convinced either way.