### PR TITLE
Display correct bedrock-autoloader version

### DIFF
--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -3,7 +3,7 @@
  * Plugin Name:  Bedrock Autoloader
  * Plugin URI:   https://github.com/roots/bedrock-autoloader
  * Description:  An autoloader that enables standard plugins to be required just like must-use plugins. The autoloaded plugins are included during mu-plugin loading. An asterisk (*) next to the name of the plugin designates the plugins that have been autoloaded.
- * Version:      1.0.3
+ * Version:      1.0.4
  * Author:       Roots
  * Author URI:   https://roots.io/
  * License:      MIT License

--- a/web/app/mu-plugins/bedrock-autoloader.php
+++ b/web/app/mu-plugins/bedrock-autoloader.php
@@ -3,7 +3,6 @@
  * Plugin Name:  Bedrock Autoloader
  * Plugin URI:   https://github.com/roots/bedrock-autoloader
  * Description:  An autoloader that enables standard plugins to be required just like must-use plugins. The autoloaded plugins are included during mu-plugin loading. An asterisk (*) next to the name of the plugin designates the plugins that have been autoloaded.
- * Version:      1.0.4
  * Author:       Roots
  * Author URI:   https://roots.io/
  * License:      MIT License


### PR DESCRIPTION
https://github.com/roots/bedrock/blob/8df74d1dfdd60953db939ac7cbd3d134310aa863/composer.lock#L342-L343

Maybe there is a better way of fetching version from lockfile or adding it to roots/bedrock-autoloader per default. But until then...