### PR TITLE
Add editor configs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ web/.htaccess
 
 # WP-CLI
 wp-cli.local.yml
+
+# Editor configs
+.idea
+.vscode


### PR DESCRIPTION
Changing the default gitignore a little bit to remove some folders added by text editors/IDE's

This makes sure these are never pushed, which makes working in a team a lot harder as overwriting each others editor configs isn't preferable.