### PR TITLE
Added auth.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ web/.htaccess
 
 # Composer
 /vendor
+auth.json
 
 # WP-CLI
 wp-cli.local.yml


### PR DESCRIPTION
auth.json is used to authenticate requests to private composer repsitories and should never be committed to the repo.