### PR TITLE
Added support for WP-CLI with superuser privileges - WP_CLI_ALLOW_ROOT: 1

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - bedrock
     depends_on:
       - database
+    environment:
+      WP_CLI_ALLOW_ROOT: 1
 
   web:
     image: nginx:alpine


### PR DESCRIPTION
It is now possible to run commands in the app container without constantly specifying the --allow-root flag.