### PR TITLE
Move webroot after ENV definition, so it can vary based on ENV

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -24,13 +24,6 @@ Env\Env::$options = 31;
 $root_dir = dirname(__DIR__);
 
 /**
- * Document Root
- *
- * @var string
- */
-$webroot_dir = $root_dir . '/web';
-
-/**
  * Use Dotenv to set required environment variables and load .env file in root
  * .env.local will override .env if it exists
  */
@@ -59,6 +52,13 @@ if (file_exists($root_dir . '/.env')) {
  * Default: production
  */
 define('WP_ENV', env('WP_ENV') ?: 'production');
+
+/**
+ * Document Root
+ *
+ * @var string
+ */
+$webroot_dir = $root_dir . '/web';
 
 /**
  * Infer WP_ENVIRONMENT_TYPE based on WP_ENV


### PR DESCRIPTION
Suggestion to move the `$webroot` definition after WP_ENV has been defined, so you can use a different web root folder, based on the `WP_ENV` value.

Example: Locally my public html folder is always called `/web` but my server has set `/public_html` as web root. So I always change it to this:

```
$webroot_dir = 'development' === WP_ENV ? $root_dir . '/web' : $root_dir . '/public_html';
```