### PR TITLE
fix: $webroot_dir phpdoc type

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -26,7 +26,7 @@ $root_dir = dirname(__DIR__);
 /**
  * Document Root
  *
- * @var string
+ * @var non-falsy-string
  */
 $webroot_dir = $root_dir . '/web';
 


### PR DESCRIPTION
This fixes the following phpstan error regarding the type of $webroot_dir declared in the phpdoc :
```
PHPDoc tag @var with type string is not subtype of native type  
         non-falsy-string.                                               
         🪪  varTag.nativeType        
```